### PR TITLE
Deep link to active ride screen if app is on `routeDetails` but not on the activity's route

### DIFF
--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -95,7 +95,8 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
                   train.stopStations.length === 0 && (
                     <RouteLine
                       style={{ start: "35.44%", height: 30 }}
-                      state={isRideOnThisRoute ? stations[train.destinationStationId].bottom : "idle"}
+                      // TODO: The line state doesn't work properly
+                      state={isRideOnThisRoute ? stations[train.destinationStationId]?.bottom : "idle"}
                     />
                   )}
 

--- a/app/utils/helpers/ride-helpers.ts
+++ b/app/utils/helpers/ride-helpers.ts
@@ -1,4 +1,5 @@
 import { RouteItem, Train } from "../../services/api"
+import { isEqual } from "lodash"
 
 /**
  * Find the closest station to the current time.
@@ -49,20 +50,6 @@ export function getTrainFromStationId(route: RouteItem, stationId: number): Trai
   return (
     route.trains.find((t) => t.originStationId === stationId) || route.trains.find((t) => t.destinationStationId === stationId)
   )
-}
-
-function isEqual(arr1: any[], arr2: any[]) {
-  if (arr1.length !== arr2.length) {
-    return false
-  }
-
-  for (let i = 0; i < arr1.length; i++) {
-    if (arr1[i] !== arr2[i]) {
-      return false
-    }
-  }
-
-  return true
 }
 
 export function getSelectedRide(routes: RouteItem[], rideTrainNumbers: number[]) {

--- a/ios/BetterRailWidget/Live Activity/BetterRailLiveActivity.swift
+++ b/ios/BetterRailWidget/Live Activity/BetterRailLiveActivity.swift
@@ -4,44 +4,49 @@ import SwiftUI
 
 
 struct BetterRailLiveActivity: Widget {
-    let widgetURL = URL(string: "liveActivity")
-    var body: some WidgetConfiguration {
-        ActivityConfiguration(for: BetterRailActivityAttributes.self) { context in
-          // Lock screen/banner UI goes here
-          LockScreenLiveActivityView(vm: ActivityViewModel(context: context))
-            .padding()
-            .background(Color(UIColor.systemBackground))
-            .widgetURL(widgetURL)
+  func deepLinkURL(_ trainNumbers: [Int]) -> URL {
+    // convert train numbers to be used as a URL parameter
+    let urlParam = trainNumbers.map(String.init).joined(separator: ",")
+    return URL(string: "liveActivity://?trains=\(urlParam)")!
+  }
+  
+  var body: some WidgetConfiguration {
+      ActivityConfiguration(for: BetterRailActivityAttributes.self) { context in
+        // Lock screen/banner UI goes here
+        LockScreenLiveActivityView(vm: ActivityViewModel(context: context))
+          .padding()
+          .background(Color(UIColor.systemBackground))
+          .widgetURL(deepLinkURL(context.attributes.trainNumbers))
 
-        } dynamicIsland: { context in
-        let vm = ActivityViewModel(context: context)
-        return DynamicIsland {
-              // Expanded UI goes here.  Compose the expanded UI through
-              // various regions, like leading/trailing/center/bottom
-            DynamicIslandExpandedRegion(.leading, priority: 90.0) {
-              LeadingView(vm: vm)
-                .dynamicIsland(verticalPlacement: .belowIfTooWide)
-            }
-            DynamicIslandExpandedRegion(.trailing) {
-                VStack {
-                  Spacer()
-                  TimeInformation(vm: vm, placement: .dynamicIsland)
-                }
-              }
-              DynamicIslandExpandedRegion(.bottom) {
-                RideInformationBar(vm: vm, placement: .dynamicIsland)
-              }
-          } compactLeading: {
-            CircularProgressView(vm: vm)
-          } compactTrailing: {
-            Text("\(String(getMinutesLeft(targetDate: getStatusEndDate(context: context)))) min")
-              .foregroundColor(vm.status.color)
-          } minimal: {
-            CircularProgressView(vm: vm)
+      } dynamicIsland: { context in
+      let vm = ActivityViewModel(context: context)
+      return DynamicIsland {
+            // Expanded UI goes here.  Compose the expanded UI through
+            // various regions, like leading/trailing/center/bottom
+          DynamicIslandExpandedRegion(.leading, priority: 90.0) {
+            LeadingView(vm: vm)
+              .dynamicIsland(verticalPlacement: .belowIfTooWide)
           }
-          .widgetURL(widgetURL)
-          .keylineTint(context.state.status.color)
-      }
+          DynamicIslandExpandedRegion(.trailing) {
+              VStack {
+                Spacer()
+                TimeInformation(vm: vm, placement: .dynamicIsland)
+              }
+            }
+            DynamicIslandExpandedRegion(.bottom) {
+              RideInformationBar(vm: vm, placement: .dynamicIsland)
+            }
+        } compactLeading: {
+          CircularProgressView(vm: vm)
+        } compactTrailing: {
+          Text("\(String(getMinutesLeft(targetDate: getStatusEndDate(context: context)))) min")
+            .foregroundColor(vm.status.color)
+        } minimal: {
+          CircularProgressView(vm: vm)
+        }
+        .widgetURL(deepLinkURL(context.attributes.trainNumbers))
+        .keylineTint(context.state.status.color)
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@storybook/react-native-server": "5.3.23",
     "@types/i18n-js": "3.0.3",
     "@types/jest": "^29.2.1",
+    "@types/lodash": "^4.14.194",
     "@types/ramda": "0.27.32",
     "@types/react": "~18.0.27",
     "@types/react-test-renderer": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,6 +4737,11 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.194":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
+
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"


### PR DESCRIPTION
also
- fixed a line state on routes with no exchange
- switched to use lodash `isEqual` method when checking for array equality in one of the ride helper methods.