### PR TITLE
Fix `route` navigation param not updating & incorrect delay calculation

### DIFF
--- a/app/hooks/use-ride-progress/use-ride-route.ts
+++ b/app/hooks/use-ride-progress/use-ride-route.ts
@@ -1,4 +1,3 @@
-import { useNavigation } from "@react-navigation/native"
 import { RouteItem } from "../../services/api"
 import { useQueryClient } from "react-query"
 import { useEffect, useMemo, useState } from "react"
@@ -13,9 +12,7 @@ const api = new RouteApi()
  * This function is used to find the next station in the route
  */
 export function useRideRoute(route: RouteItem) {
-  const { ride } = useStores()
-  // we'll need this to update the routeItem in the navigation params
-  const navigation = useNavigation()
+  const { routePlan, ride } = useStores()
 
   // we'll need this to update the query cached routes when we refetch routes
   const queryClient = useQueryClient()
@@ -46,13 +43,10 @@ export function useRideRoute(route: RouteItem) {
   const updateRide = async () => {
     const updatedRoute = await refetchRoute()
 
-    // update the screen routeItem
-    // TOFIX: This sometimes fails.
-    // @ts-expect-error
-    navigation.setParams({ routeItem: updatedRoute })
-
-    // update the ride store route
-    ride.setRoute(updatedRoute)
+    if (ride.id) {
+      // update the ride store route if a ride is active
+      ride.setRoute(updatedRoute)
+    }
 
     setDelay(updatedRoute.delay)
 

--- a/app/hooks/use-ride-progress/use-ride-route.ts
+++ b/app/hooks/use-ride-progress/use-ride-route.ts
@@ -31,7 +31,7 @@ export function useRideRoute(route: RouteItem) {
 
     // update the query cached routes
     queryClient.setQueryData(
-      ["origin", originId, "destination", destinationId, "time", new Date(route.departureTime).getDate()],
+      ["origin", originId, "destination", destinationId, "time", new Date(routePlan.date.getDate())],
       routes,
     )
 

--- a/app/hooks/use-ride-progress/use-ride-route.ts
+++ b/app/hooks/use-ride-progress/use-ride-route.ts
@@ -47,6 +47,7 @@ export function useRideRoute(route: RouteItem) {
     const updatedRoute = await refetchRoute()
 
     // update the screen routeItem
+    // TOFIX: This sometimes fails.
     // @ts-expect-error
     navigation.setParams({ routeItem: updatedRoute })
 

--- a/app/hooks/use-ride-progress/use-ride-route.ts
+++ b/app/hooks/use-ride-progress/use-ride-route.ts
@@ -31,7 +31,7 @@ export function useRideRoute(route: RouteItem) {
 
     // update the query cached routes
     queryClient.setQueryData(
-      ["origin", originId, "destination", destinationId, "time", new Date(updatedRoute.departureTime).getDate()],
+      ["origin", originId, "destination", destinationId, "time", new Date(route.departureTime).getDate()],
       routes,
     )
 

--- a/app/models/ride/ride.ts
+++ b/app/models/ride/ride.ts
@@ -4,7 +4,6 @@ import { Platform } from "react-native"
 import iOSHelpers from "../../utils/ios-helpers"
 import { trainRouteSchema } from "../train-routes/train-routes"
 import { RouteItem } from "../../services/api"
-import { toJS } from "mobx"
 
 const startRideHandler: (route: RouteItem) => Promise<string> = Platform.select({
   ios: iOSHelpers.startLiveActivity,

--- a/app/screens/route-details/components/index.ts
+++ b/app/screens/route-details/components/index.ts
@@ -1,3 +1,7 @@
 export * from "./route-station-card"
 export * from "./route-stop-card"
 export * from "./route-exchange-details"
+export * from "./route-line"
+export * from "./long-route-warning"
+export * from "./start-ride-button"
+export * from "./live-ride-sheet"

--- a/app/screens/route-details/components/live-ride-sheet.tsx
+++ b/app/screens/route-details/components/live-ride-sheet.tsx
@@ -58,19 +58,17 @@ export const LiveRideSheet = observer(function LiveRideSheet(props: { progress; 
       }}
     >
       <Text style={{ fontSize: 20, fontWeight: "bold", color: color.success }}>{progressText}</Text>
-      {ride.id ? (
-        <StopButton
-          onPress={() => {
-            ride.stopRide(ride.id)
 
-            if (screenName === "activeRide") {
-              navigation.goBack()
-            }
-          }}
-        />
-      ) : (
-        <ActivityIndicator />
-      )}
+      <StopButton
+        loading={!ride.id}
+        onPress={() => {
+          ride.stopRide(ride.id)
+
+          if (screenName === "activeRide") {
+            navigation.goBack()
+          }
+        }}
+      />
       <BlurView
         style={{ position: "absolute", top: 0, left: 0, bottom: 0, right: 0, zIndex: -1 }}
         blurType={isDarkMode ? "ultraThinMaterialDark" : "xlight"}
@@ -81,7 +79,7 @@ export const LiveRideSheet = observer(function LiveRideSheet(props: { progress; 
   )
 })
 
-const StopButton = (props: PressableProps) => (
+const StopButton = (props: { loading: boolean } & PressableProps) => (
   <Pressable
     style={({ pressed }) => [
       {
@@ -95,6 +93,10 @@ const StopButton = (props: PressableProps) => (
     ]}
     {...props}
   >
-    <Image source={require("../../../../assets/stop-rect.ios.png")} style={{ width: 17.5, height: 17.5 }} />
+    {props.loading ? (
+      <ActivityIndicator color="white" />
+    ) : (
+      <Image source={require("../../../../assets/stop-rect.ios.png")} style={{ width: 17.5, height: 17.5 }} />
+    )}
   </Pressable>
 )

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -23,11 +23,17 @@ const ROOT: ViewStyle = {
 }
 
 export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }: RouteDetailsScreenProps) {
-  const { routeItem } = route.params
   const { ride } = useStores()
 
   // we re-run this check every time the ride changes
-  const isRideOnThisRoute = useMemo(() => ride.isRouteActive(routeItem), [ride.route])
+  const isRideOnThisRoute = useMemo(() => ride.isRouteActive(route.params.routeItem), [ride.route])
+
+  // if the ride is on this route, we use the ride's route, since it has the latest data
+  // otherwise we use the route from the route params
+  const routeItem = useMemo(() => {
+    if (isRideOnThisRoute) return ride.route as unknown as RouteItem
+    return route.params.routeItem
+  }, [isRideOnThisRoute, ride.route, route.params.routeItem])
 
   const progress = useRideProgress({ route: routeItem, enabled: isRideOnThisRoute })
   const { stations } = progress

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -1,23 +1,21 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { useEffect, useMemo, useState } from "react"
-import { observer } from "mobx-react-lite"
 import { View, ViewStyle } from "react-native"
-import { RouteDetailsHeader, Screen } from "../../components"
-import { RouteDetailsScreenProps } from "../../navigators/main-navigator"
-import { color, spacing } from "../../theme"
+import { observer } from "mobx-react-lite"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { SharedElement } from "react-navigation-shared-element"
 import { ScrollView } from "react-native-gesture-handler"
+import Animated, { FadeInDown, FadeOutDown } from "react-native-reanimated"
 import { format } from "date-fns"
-import { RouteStationCard, RouteStopCard, RouteExchangeDetails } from "./components"
 
 import { useStores } from "../../models"
-import { LiveRideSheet } from "./components/live-ride-sheet"
-import { LongRouteWarning } from "./components/long-route-warning"
-import { StartRideButton } from "./components/start-ride-button"
+import { RouteItem } from "../../services/api"
 import { useRideProgress } from "../../hooks/use-ride-progress"
-import { RouteLine } from "./components/route-line"
-import Animated, { FadeInDown, FadeOutDown } from "react-native-reanimated"
+import { RouteDetailsScreenProps } from "../../navigators/main-navigator"
+import { color, spacing } from "../../theme"
+import { RouteDetailsHeader, Screen } from "../../components"
+import { RouteStationCard, RouteStopCard, RouteLine, RouteExchangeDetails } from "./components"
+import { LiveRideSheet, LongRouteWarning, StartRideButton } from "./components"
 
 const ROOT: ViewStyle = {
   flex: 1,

--- a/app/utils/helpers/ride-helpers.ts
+++ b/app/utils/helpers/ride-helpers.ts
@@ -6,7 +6,7 @@ import { isEqual } from "lodash"
  */
 export function findClosestStationInRoute(route: RouteItem) {
   const now = Date.now()
-  const delay = route.delay
+  const delay = route.delay * 60 * 1000
 
   for (let i = 0; i < route.trains.length; i++) {
     const train = route.trains[i]


### PR DESCRIPTION
The ride progress hooks are using the `RouteItem` from the navigation params. 
When the route is being updated, we try to update the navigation params through `navigation.setParams`, but it seems like the method not stable - so it's better not rely on it and use the route from the `ride` store instead.

Also, the delay value that was being used to calculate the `nextStationId` was missing the conversion to milliseconds, hence the clunky details progress view.