### PR TITLE
Improve Live Activities UI on Hebrew

### DIFF
--- a/ios/BetterRailWidget/Live Activity/Views/Lock Screen/InTransitView.swift
+++ b/ios/BetterRailWidget/Live Activity/Views/Lock Screen/InTransitView.swift
@@ -13,12 +13,16 @@ struct LockScreenInTransitView: View {
       HStack(alignment: .bottom) {
         VStack(alignment: .leading) {
           if (vm.status == .arrived) {
-            Text("arrived at").font(.caption)
+            Text("arrived at").font(.subheadline2)
           } else {
-            Text("next station").font(.caption)
+            Text("next station")
+              .fontWeight(vm.isRTL ? .regular : .light)
+              .font(vm.isRTL ? .subheadline2 : .caption)
           }
 
-          Text(vm.nextStop.name).fontWeight(.heavy).fontWidth(Font.Width(0.1))
+          Text(vm.nextStop.name)
+            .font(vm.isRTL ? .body : .callout).heavyWide()
+
         }
 
         Spacer()

--- a/ios/BetterRailWidget/Live Activity/Views/Lock Screen/WaitForTrainView.swift
+++ b/ios/BetterRailWidget/Live Activity/Views/Lock Screen/WaitForTrainView.swift
@@ -28,11 +28,12 @@ struct LockScreenWaitingForTrainView: View {
       ActivityHeader(vm: vm)
 
       HStack(alignment: .lastTextBaseline) {
-        VStack(alignment: .leading, spacing: 2.0) {
+        VStack(alignment: .leading, spacing: vm.isRTL ? 1.0 : 2.0) {
           Text(vm.status == .inExchange ? "wait in" : "headed to")
-            .font(vm.isEnglish ? .caption2 : .caption)
+            .fontWeight(vm.isRTL ? .regular : .light)
+            .font(vm.isRTL ? .subheadline2 : .caption2)
           Text("\(vm.destination.name)")
-            .font(vm.isEnglish ? .callout : .body).heavyWide()
+            .font(vm.isRTL ? .body : .callout).heavyWide()
         }
         
         Spacer()

--- a/ios/BetterRailWidget/Live Activity/Views/TimeInformation.swift
+++ b/ios/BetterRailWidget/Live Activity/Views/TimeInformation.swift
@@ -37,17 +37,17 @@ struct TimeInformation: View {
                 .accessibilityLabel("time left depart")
             }
 
-            HStack (spacing: 2) {
+            HStack (alignment: .lastTextBaseline, spacing: vm.isRTL ? 4 : 2) {
               Text("depart")
-                .fontWeight(vm.isEnglish ? .light : .regular)
-                .font(vm.isEnglish ? .caption2 : .caption)
+                .fontWeight(vm.isRTL ? .regular : .light)
+                .font(vm.isRTL ? .subheadline2 : .caption2)
               
               // hide the original time during delay, if the screen space is limited
               if (delay == 0 || delay > 0 && (placement == .lockScreen || vm.isWideScreen)) {
                 Text(formatDateHour(departureDate))
                   .bold()
                   .strikethrough(vm.delay > 0 ? true : false)
-                  .font(.caption)
+                  .font(vm.isRTL ? .caption : .caption2)
               }
               
               if (delay != 0) {


### PR DESCRIPTION
using `isRTL` instead of `isEnglish` since somehow the live activities UI thinks the device is in English, even though the device main locale is English (condition is OK inside the app)

<img src="https://user-images.githubusercontent.com/13344923/241171754-dc2b8873-8d44-4225-af54-77ee8ce3580f.png" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2023-05-26 at 14 28 32" width="250">

Resolves #185 