### PR TITLE
Resolved issue with black screen when device language is not supported

### DIFF
--- a/app/i18n/i18n.ts
+++ b/app/i18n/i18n.ts
@@ -30,10 +30,10 @@ export function setInitialLanguage() {
     changeUserLanguage("he")
   } else if (Localization.locale.startsWith("ar")) {
     changeUserLanguage("ar")
-  } else if (Localization.locale.startsWith("en")) {
-    changeUserLanguage("en")
   } else if (Localization.locale.startsWith("ru")) {
     changeUserLanguage("ru")
+  } else {
+    changeUserLanguage("en")
   }
 }
 


### PR DESCRIPTION
if the device language isn't Hebrew, Arabic or Russian the app will set the user language to English 
Fixed #201 