### PR TITLE
Fixed widget duplicate times

### DIFF
--- a/ios/BetterRailWidget/EntriesGenerator.swift
+++ b/ios/BetterRailWidget/EntriesGenerator.swift
@@ -20,17 +20,26 @@ struct EntriesGenerator {
       }
       
       if tomorrowRoutes.count > 0 {
-        var tomorrowEntries = generateEntriesForRoutes(tomorrowRoutes, originId: originId, destinationId: destinationId)
-        tomorrowEntries[0].date = lastTrainEntryDate
+        let currentDateAtMidnight = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: Date())!
+        let firstRouteDate = isoDateStringToDate(tomorrowRoutes[0].departureTime)
+        let daysDiff = Calendar.current.dateComponents([.day], from: currentDateAtMidnight, to: firstRouteDate).day ?? 0
         
-        // Add tomorrow's first entry as the last entry for today
-        entries.append(tomorrowEntries[0])
+        if daysDiff < 2 {
+          var tomorrowEntries = generateEntriesForRoutes(tomorrowRoutes, originId: originId, destinationId: destinationId)
+          tomorrowEntries[0].date = lastTrainEntryDate
+          
+          // Add tomorrow's first entry as the last entry for today
+          entries.append(tomorrowEntries[0])
+        } else {
+          // If the first entry is two days in the future, display no trains are available
+          entries = [getEmptyEntry(originId: originId, destinationId: destinationId, date: lastTrainEntryDate)]
+        }
       } else {
         // If there are no trains coming up tomorrow, display an empty entry at the end of today's entries
         entries.append(getEmptyEntry(originId: originId, destinationId: destinationId, date: lastTrainEntryDate))
       }
     }
-        
+    
     return entries
   }
   

--- a/ios/Utilities.swift
+++ b/ios/Utilities.swift
@@ -21,11 +21,13 @@ func getDateFromTimeString(_ timeString: String) -> Date? {
 /// Converts a date to formatted string for Israel Railways API
 func formatRouteDate(_ date: Date) -> (String, String) {
   let dateFormatter = DateFormatter()
-  dateFormatter.locale = Locale(identifier: "en_us")
+  dateFormatter.locale = Locale(identifier: "he_IL")
   
+  dateFormatter.setLocalizedDateFormatFromTemplate("yyyy-MM-dd")
   dateFormatter.dateFormat = "yyyy-MM-dd"
   let routeDate = dateFormatter.string(from: date)
   
+  dateFormatter.setLocalizedDateFormatFromTemplate("HH:mm")
   dateFormatter.dateFormat = "HH:mm"
   let routeTime = dateFormatter.string(from: date)
   
@@ -34,6 +36,8 @@ func formatRouteDate(_ date: Date) -> (String, String) {
 
 func isoDateStringToDate(_ isoDate: String) -> Date {
   let dateFormatter = DateFormatter()
+  dateFormatter.locale = Locale(identifier: "he_IL")
+  dateFormatter.setLocalizedDateFormatFromTemplate("yyyy-MM-dd'T'HH:mm:ss")
   dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
   
   if let date = dateFormatter.date(from: isoDate) {

--- a/ios/WatchBetterRail Extension/Models/RouteModel.swift
+++ b/ios/WatchBetterRail Extension/Models/RouteModel.swift
@@ -100,7 +100,7 @@ struct RouteModel {
               
               let decoder = JSONDecoder()
             do {
-                let route = try decoder.decode(RouteResult.self, from: data)
+              let route = try decoder.decode(RouteResult.self, from: data)
               completion(FetchRouteResult(status: .success, routes: route.result.travels))
             } catch {
                 print("Error decoding JSON: \(String(describing: error))")


### PR DESCRIPTION
Closes #205

- Added `he_IL` locale and `setLocalizedDateFormatFromTemplate` to all date formatters fix duplicate times issue.
- Widget currently shows trains for Sunday when it's Friday and there are no trains in Friday **and** Saturday, so there's a fix for that as well.