### PR TITLE
Show Minutes Left In Dynamic Island Minimal View

### DIFF
--- a/ios/BetterRailWidget/Live Activity/BetterRailLiveActivity.swift
+++ b/ios/BetterRailWidget/Live Activity/BetterRailLiveActivity.swift
@@ -42,13 +42,13 @@ struct BetterRailLiveActivity: Widget {
             RideInformationBar(vm: vm, placement: .dynamicIsland)
           }
         } compactLeading: {
-          CircularProgressView(vm: vm, tintColor: tintColor(context: context))
+          CircularProgressView(vm: vm, content: .icon, tintColor: tintColor(context: context))
         } compactTrailing: {
           Text("\(String(getMinutesLeft(targetDate: getStatusEndDate(context: context)))) min")
             .foregroundColor(tintColor(context: context))
             .accessibilityLabel(vm.status == .waitForTrain ? "time left depart" : "time left arrival")
         } minimal: {
-          CircularProgressView(vm: vm, tintColor: tintColor(context: context))
+          CircularProgressView(vm: vm, content: .time, tintColor: tintColor(context: context))
         }
         .widgetURL(deepLinkURL(context.attributes.trainNumbers))
         .keylineTint(tintColor(context: context))

--- a/ios/BetterRailWidget/Live Activity/Views/CircularProgressView.swift
+++ b/ios/BetterRailWidget/Live Activity/Views/CircularProgressView.swift
@@ -41,8 +41,7 @@ struct CircularProgressView: View {
       
       if content == .time && vm.context.attributes.frequentPushesEnabled && minutesLeft < 100 {
         Text(String(minutesLeft))
-          .bold()
-          .preferredFont(size: 11)
+          .font(.system(size: 11, weight: .semibold))
       } else {
         Image(systemName: iconName).font(.system(size: 8.0))
           .scaleEffect(x: vm.isRTL ? -1 : 1, y: 1, anchor: .center)

--- a/ios/BetterRailWidget/Live Activity/Views/CircularProgressView.swift
+++ b/ios/BetterRailWidget/Live Activity/Views/CircularProgressView.swift
@@ -2,8 +2,14 @@ import SwiftUI
 import WidgetKit
 import ActivityKit
 
+enum Content {
+  case icon
+  case time
+}
+
 struct CircularProgressView: View {
   var vm: ActivityViewModel
+  var content: Content
   
   var start: Date { getStatusStartDate(context: vm.context) }
   
@@ -23,13 +29,24 @@ struct CircularProgressView: View {
     }
   }
   
+  var minutesLeft: Int {
+    getMinutesLeft(targetDate: end)
+  }
+  
   var tintColor: Color
   
   var body: some View {
     ZStack {
       ProgressView(timerInterval: start...end, countsDown: false, label: {}, currentValueLabel: { EmptyView() }).progressViewStyle(.circular).tint(tintColor)
-      Image(systemName: iconName).font(.system(size: 8.0))
-        .scaleEffect(x: vm.isRTL ? -1 : 1, y: 1, anchor: .center)
+      
+      if content == .time && vm.context.attributes.frequentPushesEnabled && minutesLeft < 100 {
+        Text(String(minutesLeft))
+          .bold()
+          .preferredFont(size: 11)
+      } else {
+        Image(systemName: iconName).font(.system(size: 8.0))
+          .scaleEffect(x: vm.isRTL ? -1 : 1, y: 1, anchor: .center)
+      }
     }
   }
 }


### PR DESCRIPTION
Instead of showing the logo, show the minutes to the ride completion:

![telegram-cloud-photo-size-4-6039431756228180819-y](https://github.com/better-rail/app/assets/12946462/1df0798c-bfed-495f-9605-59d6afd2a59e)
