### PR TITLE
Avoid rendering first ride alert sheet on Android

### DIFF
--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -162,7 +162,7 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
         </Animated.View>
       )}
 
-      <FirstRideAlert ref={bottomSheetRef} />
+      {Platform.OS === "ios" && <FirstRideAlert ref={bottomSheetRef} />}
     </Screen>
   )
 })


### PR DESCRIPTION
Related only to iOS users, so it's unnecessary to render it on Android devices.