### PR TITLE
fix first ride alert sheet overflows bottom ride details

### DIFF
--- a/app/components/sheets/bottom-screen-sheet.tsx
+++ b/app/components/sheets/bottom-screen-sheet.tsx
@@ -45,7 +45,7 @@ export function BottomScreenSheet({ children, style }: BottomScreenSheetProps) {
         <BlurView
           style={{ position: "absolute", top: 0, left: 0, bottom: 0, right: 0, zIndex: -1 }}
           blurType={isDarkMode ? "ultraThinMaterialDark" : "xlight"}
-          blurAmount={30}
+          blurAmount={20}
           reducedTransparencyFallbackColor={color.tertiaryBackground as unknown as string}
         />
       )}

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -147,7 +147,11 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
       </ScrollView>
 
       {isRideOnThisRoute && (
-        <Animated.View entering={shouldFadeRideButton && FadeInDown} exiting={FadeOutDown} style={{ flex: 1 }}>
+        <Animated.View
+          entering={shouldFadeRideButton && FadeInDown}
+          exiting={FadeOutDown}
+          style={{ flex: 1, zIndex: Platform.select({ ios: 0, android: 1 }) }}
+        >
           <LiveRideSheet progress={progress} screenName={route.name} />
         </Animated.View>
       )}

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -147,7 +147,7 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
       </ScrollView>
 
       {isRideOnThisRoute && (
-        <Animated.View entering={shouldFadeRideButton && FadeInDown} exiting={FadeOutDown} style={{ flex: 1, zIndex: 1 }}>
+        <Animated.View entering={shouldFadeRideButton && FadeInDown} exiting={FadeOutDown} style={{ flex: 1 }}>
           <LiveRideSheet progress={progress} screenName={route.name} />
         </Animated.View>
       )}

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -150,6 +150,7 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
         <Animated.View
           entering={shouldFadeRideButton && FadeInDown}
           exiting={FadeOutDown}
+          // zIndex is needed for Android in order to make the button pressable
           style={{ flex: 1, zIndex: Platform.select({ ios: 0, android: 1 }) }}
         >
           <LiveRideSheet progress={progress} screenName={route.name} />


### PR DESCRIPTION
Before: 
<img src="https://user-images.githubusercontent.com/13344923/268762084-bc1593ba-7903-4ac4-ac33-bcf837769077.jpg" alt="IMAGE 2023-09-18 4:07:25 PM" width="300" />
After: 
<img src="https://user-images.githubusercontent.com/13344923/268762135-08f47f7f-f6cc-451a-92e6-6f7022e8cf70.png" alt="Simulator Screenshot - iPhone 14 Pro - 2023-09-18 at 16 06 11" width="240" />



