### PR TITLE
Fix feedback link not working on iOS

### DIFF
--- a/app/screens/settings/settings-about-screen.tsx
+++ b/app/screens/settings/settings-about-screen.tsx
@@ -101,9 +101,7 @@ export const AboutScreen = observer(function AboutScreen({ navigation }: Setting
           title={translate("settings.feedback")}
           icon="📨"
           onPress={() =>
-            Linking.openURL(
-              encodeURIComponent(`mailto:feedback@better-rail.co.il?subject=פידבק על Better Rail&body=${emailBody}`),
-            )
+            Linking.openURL(encodeURI(`mailto:feedback@better-rail.co.il?subject=פידבק על Better Rail&body=${emailBody}`))
           }
         />
       </View>


### PR DESCRIPTION
> encodeURI is used to encode a full URL whereas encodeURIComponent is used for encoding a URI component such as a query string.

[Source](https://stackoverflow.com/a/67782707/3232187)