### PR TITLE
Shorten Apple Watch analytics event names

### DIFF
--- a/app/models/favorites/favorites.ts
+++ b/app/models/favorites/favorites.ts
@@ -9,11 +9,11 @@ import { translate } from "../../i18n"
 if (Platform.OS === "ios") {
   // set analytics user property for apple watch
   getIsPaired().then((isPaired) => {
-    analytics().setUserProperty("apple_watch_paired", isPaired ? "true" : "false")
+    analytics().setUserProperty("watch_paired", isPaired ? "true" : "false")
   })
 
   getIsWatchAppInstalled().then((isInstalled) => {
-    analytics().setUserProperty("apple_watch_app_installed", isInstalled ? "true" : "false")
+    analytics().setUserProperty("watch_app_installed", isInstalled ? "true" : "false")
   })
 }
 


### PR DESCRIPTION
Due to this warning log:
```
10.7.0 - [FirebaseAnalytics][I-ACS013000] User property name is too long. The maximum supported length is 24: apple_watch_app_installed
```