### PR TITLE
Show crowd load for train routes

### DIFF
--- a/app/components/route-card/route-card.tsx
+++ b/app/components/route-card/route-card.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { useMemo } from "react"
 import { TextStyle, View, ViewStyle, Platform } from "react-native"
+import { interpolateColor } from "react-native-reanimated";
 import TouchableScale, { TouchableScaleProps } from "react-native-touchable-scale"
 import { Svg, Line } from "react-native-svg"
 import { color, spacing, typography, fontScale } from "../../theme"
@@ -22,6 +23,7 @@ const CONTAINER: ViewStyle = {
   justifyContent: "space-between",
   alignItems: "center",
   height: RouteCardHeight,
+  overflow: "hidden",
 
   paddingVertical: spacing[2],
   paddingHorizontal: spacing[4],
@@ -70,6 +72,7 @@ export interface RouteCardProps extends TouchableScaleProps {
   isMuchLonger: boolean
   stops: number
   delay: number
+  load: number
   style?: ViewStyle
   isActiveRide: boolean
   shouldShowDashedLine?: boolean
@@ -84,6 +87,7 @@ export const RouteCard = function RouteCard(props: RouteCardProps) {
     delay,
     isMuchShorter,
     isMuchLonger,
+    load,
     onPress = null,
     style,
     shouldShowDashedLine = true,
@@ -135,6 +139,8 @@ export const RouteCard = function RouteCard(props: RouteCardProps) {
         <Text style={TIME_TYPE_TEXT} tx="routes.arrival" />
         <Text style={TIME_TEXT}>{formattedArrivalTime}</Text>
       </View>
+
+      <LoadBar load={load} />
     </TouchableScale>
   )
 }
@@ -144,3 +150,15 @@ const DashedLine = () => (
     <Line stroke={color.dim} strokeWidth={4} strokeDasharray="5,5" x1="0" y1="0" x2="100%" y2={0} />
   </Svg>
 )
+
+const LoadBar = ({ load }) => {
+  const height = 3;
+  const width = `${load * 100}%`;
+  const color = interpolateColor(load, [0, 1], ["green", "red"]);
+
+  return (
+    <View style={{ height: height, backgroundColor: "rgba(0, 0, 0, 0.1)", position: "absolute", bottom: 0, left: 0, right: 0 }}>
+      <View style={{ height: "100%", width: width, backgroundColor: color }} />
+    </View>
+  );
+};

--- a/app/screens/route-list/route-list-screen.tsx
+++ b/app/screens/route-list/route-list-screen.tsx
@@ -96,6 +96,7 @@ export const RouteListScreen = observer(function RouteListScreen({ navigation, r
         departureTime={departureTime}
         arrivalTime={arrivalTime}
         delay={item.delay}
+        load={item.load}
         isActiveRide={ride.isRouteActive(item)}
         onPress={() =>
           navigation.navigate("routeDetails", {

--- a/app/services/api/rail-api.types.ts
+++ b/app/services/api/rail-api.types.ts
@@ -73,6 +73,7 @@ export type Train = {
   lastStop: string
   delay: number
   trainPosition: TrainPosition
+  load: number
 }
 
 export type RouteItem = {
@@ -86,6 +87,7 @@ export type RouteItem = {
   isMuchLonger: boolean
   isMuchShorter: boolean
   trains: Train[]
+  load: number
 }
 
 export interface Title {

--- a/app/services/api/route-api.ts
+++ b/app/services/api/route-api.ts
@@ -38,6 +38,7 @@ export class RouteApi {
             trainNumber,
             routeStations,
             trainPosition,
+            crowded,
           } = train
 
           const stopStations = train.stopStations.map((station) => {
@@ -76,6 +77,7 @@ export class RouteApi {
             stopStations,
             routeStations,
             trainPosition,
+            load: crowded,
           }
 
           return modifiedTrain
@@ -94,6 +96,7 @@ export class RouteApi {
           delay: trains?.[0].delay ?? 0,
           duration: formatRouteDuration(routeDurationInMs(departureTime, arrivalTime)),
           isExchange: trains.length > 1,
+          load: trains?.[0].load ?? 0,
         }
       })
 


### PR DESCRIPTION
Adds a bar indicator which displays crowd load for each route item.
The bar's length and color represent the crowd load (shorter and greener = less crowded, longer and redder = more crowded).

Example of current implementation:
![](https://github.com/better-rail/app/assets/86570889/08a3c10e-aa27-4d79-a114-7d690b150a73)

I do feel like it's a bit unintuitive from a first look though, so I'm open to suggestions :D