### PR TITLE
Fix crash when launching the app on MacOS

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -70,8 +70,8 @@ function App() {
 
   useEffect(() => {
     // Activate live activities listener on iOS 16.2+
-    rootStore.ride.checkLiveActivitiesSupported().then((result) => {
-      if (result === true) {
+    rootStore.ride.checkLiveActivitiesSupported().then((canRunLiveActivities) => {
+      if (canRunLiveActivities === true) {
         monitorLiveActivities()
       }
     })

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -48,7 +48,7 @@ if (__DEV__) {
 // stack navigation, use `createNativeStackNavigator` in place of `createStackNavigator`:
 // https://github.com/kmagiera/react-native-screens#using-native-stack-navigator
 import { enableScreens } from "react-native-screens"
-import { canRunLiveActivities, monitorLiveActivities } from "./utils/ios-helpers"
+import { monitorLiveActivities } from "./utils/ios-helpers"
 import { useDeepLinking } from "./hooks/use-deep-linking"
 import { openActiveRide } from "./utils/helpers/ride-helpers"
 enableScreens()

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -70,9 +70,11 @@ function App() {
 
   useEffect(() => {
     // Activate live activities listener on iOS 16.2+
-    if (canRunLiveActivities) {
-      monitorLiveActivities()
-    }
+    canRunLiveActivities().then((result) => {
+      if (result === true) {
+        monitorLiveActivities()
+      }
+    })
   }, [])
 
   useEffect(() => {

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -70,12 +70,12 @@ function App() {
 
   useEffect(() => {
     // Activate live activities listener on iOS 16.2+
-    rootStore.ride.checkLiveActivitiesSupported().then((canRunLiveActivities) => {
+    rootStore?.ride.checkLiveActivitiesSupported().then((canRunLiveActivities) => {
       if (canRunLiveActivities === true) {
         monitorLiveActivities()
       }
     })
-  }, [])
+  }, [rootStore])
 
   useEffect(() => {
     if (Platform.OS === "android") {

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -70,7 +70,7 @@ function App() {
 
   useEffect(() => {
     // Activate live activities listener on iOS 16.2+
-    canRunLiveActivities().then((result) => {
+    rootStore.ride.checkLiveActivitiesSupported().then((result) => {
       if (result === true) {
         monitorLiveActivities()
       }

--- a/app/models/ride/ride.ts
+++ b/app/models/ride/ride.ts
@@ -102,7 +102,7 @@ export const RideModel = types
       return false
     },
     async checkLiveRideAuthorization() {
-      if (!self.canRunLiveActivities) {
+      if (self.canRunLiveActivities) {
         const info = await iOSHelpers.activityAuthorizationInfo()
         this.setActivityAuthorizationInfo(info)
       } else if (Platform.OS === "android") {

--- a/app/models/ride/ride.ts
+++ b/app/models/ride/ride.ts
@@ -92,10 +92,13 @@ export const RideModel = types
     setActivityAuthorizationInfo(newInfo: ActivityAuthorizationInfo) {
       self.activityAuthorizationInfo = newInfo
     },
+    setCanRunLiveActivities(value: boolean) {
+      self.canRunLiveActivities = value
+    },
     async checkLiveActivitiesSupported() {
       if (Platform.OS === "ios") {
         const supported = await iOSHelpers.canRunLiveActivities()
-        self.canRunLiveActivities = supported
+        this.setCanRunLiveActivities(supported)
         return supported
       }
 

--- a/app/models/ride/ride.ts
+++ b/app/models/ride/ride.ts
@@ -2,7 +2,7 @@ import { Instance, SnapshotOut, types } from "mobx-state-tree"
 import { omit } from "ramda"
 import { Platform } from "react-native"
 import AndroidHelpers from "../../utils/android-helpers"
-import iOSHelpers, { ActivityAuthorizationInfo, canRunLiveActivities } from "../../utils/ios-helpers"
+import iOSHelpers, { ActivityAuthorizationInfo, liveActivitiesSupported } from "../../utils/ios-helpers"
 import { trainRouteSchema } from "../train-routes/train-routes"
 import { RouteItem } from "../../services/api"
 import { RouteApi } from "../../services/api/route-api"
@@ -89,6 +89,8 @@ export const RideModel = types
       self.activityAuthorizationInfo = newInfo
     },
     async checkLiveRideAuthorization() {
+      const canRunLiveActivities = await iOSHelpers.canRunLiveActivities()
+
       if (canRunLiveActivities) {
         const info = await iOSHelpers.activityAuthorizationInfo()
         this.setActivityAuthorizationInfo(info)
@@ -106,7 +108,7 @@ export const RideModel = types
       this.checkLiveRideAuthorization()
     },
     startRide(route: RouteItem) {
-      if (Platform.OS === "ios" && !canRunLiveActivities) return
+      if (Platform.OS === "ios" && !liveActivitiesSupported) return
 
       this.setRideLoading(true)
       this.setRoute(route)
@@ -130,7 +132,7 @@ export const RideModel = types
         })
     },
     stopRide(rideId: string) {
-      if (Platform.OS === "ios" && !canRunLiveActivities) return Promise.resolve()
+      if (Platform.OS === "ios" && !liveActivitiesSupported) return Promise.resolve()
 
       this.setRideLoading(true)
       this.setRideId(undefined)
@@ -153,7 +155,7 @@ export const RideModel = types
       self.rideCount = count
     },
     isRideActive(rideId: string) {
-      if (canRunLiveActivities) {
+      if (liveActivitiesSupported) {
         iOSHelpers.isRideActive(rideId).then((tokens) => {
           // TODO: Check if ride Id exists in the array.
           // Currently .rideId arrives always empty, so we only check if the array is empty.

--- a/app/models/ride/ride.ts
+++ b/app/models/ride/ride.ts
@@ -66,6 +66,10 @@ export const RideModel = types
      * Number of rides the user has taken
      */
     rideCount: types.optional(types.number, 0),
+    /**
+     * Whether the user device can run live activities
+     */
+    canRunLiveActivities: types.optional(types.boolean, false),
   })
   .views((self) => ({
     get originId() {
@@ -87,6 +91,15 @@ export const RideModel = types
     },
     setActivityAuthorizationInfo(newInfo: ActivityAuthorizationInfo) {
       self.activityAuthorizationInfo = newInfo
+    },
+    async checkLiveActivitiesSupported() {
+      if (Platform.OS === "ios") {
+        const supported = await iOSHelpers.canRunLiveActivities()
+        self.canRunLiveActivities = supported
+        return supported
+      }
+
+      return false
     },
     async checkLiveRideAuthorization() {
       const canRunLiveActivities = await iOSHelpers.canRunLiveActivities()

--- a/app/screens/planner/planner-screen-header.tsx
+++ b/app/screens/planner/planner-screen-header.tsx
@@ -12,7 +12,6 @@ import { ImportantAnnouncementBar } from "./Important-announcement-bar"
 import { PopUpMessage, railApi } from "../../services/api"
 import { useQuery } from "react-query"
 import { head, isEmpty } from "lodash"
-import { canRunLiveActivities } from "../../utils/ios-helpers"
 
 const HEADER_WRAPPER: ViewStyle = {
   flexDirection: "row",
@@ -60,13 +59,11 @@ export const PlannerScreenHeader = observer(function PlannerScreenHeader() {
     // and they haven't seen the live announcement screen yet,
     // and the user can run live activities (iOS only)
     if (routePlan.origin && routePlan.destination) {
-      canRunLiveActivities().then((result) => {
-        if (result === false) return
-
+      if (Platform.OS === "android" || ride.canRunLiveActivities) {
         storage.load("seenLiveAnnouncement").then((hasSeenLiveAnnouncementScreen) => {
           if (!hasSeenLiveAnnouncementScreen) setDisplayNewBadge(true)
         })
-      })
+      }
     }
   }, [])
 

--- a/app/screens/planner/planner-screen-header.tsx
+++ b/app/screens/planner/planner-screen-header.tsx
@@ -60,10 +60,12 @@ export const PlannerScreenHeader = observer(function PlannerScreenHeader() {
     // and they haven't seen the live announcement screen yet,
     // and the user can run live activities (iOS only)
     if (routePlan.origin && routePlan.destination) {
-      if (Platform.OS === "ios" && !canRunLiveActivities) return
+      canRunLiveActivities().then((result) => {
+        if (result === false) return
 
-      storage.load("seenLiveAnnouncement").then((hasSeenLiveAnnouncementScreen) => {
-        if (!hasSeenLiveAnnouncementScreen) setDisplayNewBadge(true)
+        storage.load("seenLiveAnnouncement").then((hasSeenLiveAnnouncementScreen) => {
+          if (!hasSeenLiveAnnouncementScreen) setDisplayNewBadge(true)
+        })
       })
     }
   }, [])

--- a/app/screens/planner/planner-screen-header.tsx
+++ b/app/screens/planner/planner-screen-header.tsx
@@ -12,6 +12,7 @@ import { ImportantAnnouncementBar } from "./Important-announcement-bar"
 import { PopUpMessage, railApi } from "../../services/api"
 import { useQuery } from "react-query"
 import { head, isEmpty } from "lodash"
+import { canRunLiveActivities } from "../../utils/ios-helpers"
 
 const HEADER_WRAPPER: ViewStyle = {
   flexDirection: "row",
@@ -59,6 +60,8 @@ export const PlannerScreenHeader = observer(function PlannerScreenHeader() {
     // and they haven't seen the live announcement screen yet,
     // and the user can run live activities (iOS only)
     if (routePlan.origin && routePlan.destination) {
+      if (Platform.OS === "ios" && !canRunLiveActivities) return
+
       storage.load("seenLiveAnnouncement").then((hasSeenLiveAnnouncementScreen) => {
         if (!hasSeenLiveAnnouncementScreen) setDisplayNewBadge(true)
       })

--- a/app/screens/route-details/components/start-ride-button.tsx
+++ b/app/screens/route-details/components/start-ride-button.tsx
@@ -11,7 +11,7 @@ import { differenceInMinutes, isAfter } from "date-fns"
 import { timezoneCorrection } from "../../../utils/helpers/date-helpers"
 import { color, fontScale } from "../../../theme"
 import { useStores } from "../../../models"
-import { canRunLiveActivities } from "../../../utils/ios-helpers"
+import { liveActivitiesSupported } from "../../../utils/ios-helpers"
 import { AndroidNotificationSetting, AuthorizationStatus } from "@notifee/react-native"
 import InAppReview from "react-native-in-app-review"
 
@@ -60,11 +60,12 @@ export const StartRideButton = observer(function StartRideButton(props: StartRid
     differenceInMinutes(route.departureTime + route.delay * 60000, timezoneCorrection(new Date()).getTime()) > 60
 
   const areActivitiesDisabled = Platform.select({
-    ios: () => !canRunLiveActivities || !(ride?.activityAuthorizationInfo?.areActivitiesEnabled ?? true),
+    ios: () => !liveActivitiesSupported || !(ride?.activityAuthorizationInfo?.areActivitiesEnabled ?? true),
     android: () =>
       ride.notifeeSettings?.notifications !== AuthorizationStatus.AUTHORIZED ||
       ride.notifeeSettings?.alarms !== AndroidNotificationSetting.ENABLED,
   })
+
   const isStartRideButtonDisabled = isRouteInFuture || isRouteInPast || areActivitiesDisabled()
 
   const startRide = async () => {

--- a/app/screens/route-details/components/start-ride-button.tsx
+++ b/app/screens/route-details/components/start-ride-button.tsx
@@ -11,7 +11,6 @@ import { differenceInMinutes, isAfter } from "date-fns"
 import { timezoneCorrection } from "../../../utils/helpers/date-helpers"
 import { color, fontScale } from "../../../theme"
 import { useStores } from "../../../models"
-import { liveActivitiesSupported } from "../../../utils/ios-helpers"
 import { AndroidNotificationSetting, AuthorizationStatus } from "@notifee/react-native"
 import InAppReview from "react-native-in-app-review"
 
@@ -60,7 +59,7 @@ export const StartRideButton = observer(function StartRideButton(props: StartRid
     differenceInMinutes(route.departureTime + route.delay * 60000, timezoneCorrection(new Date()).getTime()) > 60
 
   const areActivitiesDisabled = Platform.select({
-    ios: () => !liveActivitiesSupported || !(ride?.activityAuthorizationInfo?.areActivitiesEnabled ?? true),
+    ios: () => !ride.canRunLiveActivities || !(ride?.activityAuthorizationInfo?.areActivitiesEnabled ?? true),
     android: () =>
       ride.notifeeSettings?.notifications !== AuthorizationStatus.AUTHORIZED ||
       ride.notifeeSettings?.alarms !== AndroidNotificationSetting.ENABLED,

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -24,7 +24,7 @@ import {
   StartRideButton,
 } from "./components"
 import BottomSheet from "@gorhom/bottom-sheet"
-import { canRunLiveActivities } from "../../utils/ios-helpers"
+import { canRunLiveActivities, liveActivitiesSupported } from "../../utils/ios-helpers"
 import { LivePermissionsSheet } from "./components/live-permissions-sheet"
 
 const ROOT: ViewStyle = {
@@ -33,6 +33,8 @@ const ROOT: ViewStyle = {
 }
 export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }: RouteDetailsScreenProps) {
   const { ride } = useStores()
+
+  const [showStartRideButton, setShowStartRideButton] = useState(false)
 
   const permissionSheetRef = useRef<BottomSheet>(null)
 
@@ -79,6 +81,18 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
       ride.stopRide(ride.id)
     }
   }, [progress.status, ride.id])
+
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      setShowStartRideButton(true)
+      return
+    }
+
+    canRunLiveActivities().then((result) => {
+      const showButton = result && !isRideOnThisRoute
+      setShowStartRideButton(showButton)
+    })
+  }, [isRideOnThisRoute])
 
   return (
     <>
@@ -171,7 +185,7 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
           </Animated.View>
         )}
 
-        {(Platform.OS === "android" || canRunLiveActivities) && !isRideOnThisRoute && (
+        {showStartRideButton && (
           <Animated.View
             entering={shouldFadeRideButton && FadeInDown.delay(100)}
             exiting={FadeOutDown}

--- a/app/screens/route-details/route-details-screen.tsx
+++ b/app/screens/route-details/route-details-screen.tsx
@@ -24,7 +24,6 @@ import {
   StartRideButton,
 } from "./components"
 import BottomSheet from "@gorhom/bottom-sheet"
-import { canRunLiveActivities, liveActivitiesSupported } from "../../utils/ios-helpers"
 import { LivePermissionsSheet } from "./components/live-permissions-sheet"
 
 const ROOT: ViewStyle = {
@@ -33,8 +32,6 @@ const ROOT: ViewStyle = {
 }
 export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }: RouteDetailsScreenProps) {
   const { ride } = useStores()
-
-  const [showStartRideButton, setShowStartRideButton] = useState(false)
 
   const permissionSheetRef = useRef<BottomSheet>(null)
 
@@ -81,18 +78,6 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
       ride.stopRide(ride.id)
     }
   }, [progress.status, ride.id])
-
-  useEffect(() => {
-    if (Platform.OS === "android") {
-      setShowStartRideButton(true)
-      return
-    }
-
-    canRunLiveActivities().then((result) => {
-      const showButton = result && !isRideOnThisRoute
-      setShowStartRideButton(showButton)
-    })
-  }, [isRideOnThisRoute])
 
   return (
     <>
@@ -185,7 +170,7 @@ export const RouteDetailsScreen = observer(function RouteDetailsScreen({ route }
           </Animated.View>
         )}
 
-        {showStartRideButton && (
+        {(Platform.OS === "android" || ride.canRunLiveActivities) && !isRideOnThisRoute && (
           <Animated.View
             entering={shouldFadeRideButton && FadeInDown.delay(100)}
             exiting={FadeOutDown}

--- a/app/utils/ios-helpers.tsx
+++ b/app/utils/ios-helpers.tsx
@@ -7,11 +7,7 @@ export async function canRunLiveActivities() {
   const isRunningOnMac = await RNBetterRail.isRunningOnMac()
   const deviceSupported = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2
 
-  if (deviceSupported && !isRunningOnMac) {
-    return true
-  }
-
-  return false
+  return deviceSupported && !isRunningOnMac
 }
 
 export function donateRouteIntent(originId: string, destinationId: string) {

--- a/app/utils/ios-helpers.tsx
+++ b/app/utils/ios-helpers.tsx
@@ -3,7 +3,11 @@ import { RouteItem } from "../services/api"
 
 const { RNBetterRail } = NativeModules
 
-export const canRunLiveActivities = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2
+function isRunningOnMac() {
+  return RNBetterRail.isRunningOnMac()
+}
+
+export const canRunLiveActivities = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2 && !isRunningOnMac()
 
 export function donateRouteIntent(originId: string, destinationId: string) {
   RNBetterRail.donateRouteIntent(originId, destinationId)

--- a/app/utils/ios-helpers.tsx
+++ b/app/utils/ios-helpers.tsx
@@ -3,11 +3,17 @@ import { RouteItem } from "../services/api"
 
 const { RNBetterRail } = NativeModules
 
-function isRunningOnMac() {
-  return RNBetterRail.isRunningOnMac()
-}
+export const liveActivitiesSupported = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2
 
-export const canRunLiveActivities = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2 && !isRunningOnMac()
+export async function canRunLiveActivities() {
+  const isRunningOnMac = await RNBetterRail.isRunningOnMac()
+
+  if (liveActivitiesSupported && !isRunningOnMac) {
+    return true
+  }
+
+  return false
+}
 
 export function donateRouteIntent(originId: string, destinationId: string) {
   RNBetterRail.donateRouteIntent(originId, destinationId)
@@ -102,6 +108,7 @@ export default {
   startLiveActivity,
   endLiveActivity,
   isRideActive,
+  liveActivitiesSupported,
   canRunLiveActivities,
   activityAuthorizationInfo,
 }

--- a/app/utils/ios-helpers.tsx
+++ b/app/utils/ios-helpers.tsx
@@ -3,12 +3,11 @@ import { RouteItem } from "../services/api"
 
 const { RNBetterRail } = NativeModules
 
-export const liveActivitiesSupported = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2
-
 export async function canRunLiveActivities() {
   const isRunningOnMac = await RNBetterRail.isRunningOnMac()
+  const deviceSupported = Platform.OS == "ios" && parseFloat(Platform.Version) >= 16.2
 
-  if (liveActivitiesSupported && !isRunningOnMac) {
+  if (deviceSupported && !isRunningOnMac) {
     return true
   }
 
@@ -108,7 +107,6 @@ export default {
   startLiveActivity,
   endLiveActivity,
   isRideActive,
-  liveActivitiesSupported,
   canRunLiveActivities,
   activityAuthorizationInfo,
 }

--- a/ios/BetterRail.xcodeproj/project.pbxproj
+++ b/ios/BetterRail.xcodeproj/project.pbxproj
@@ -1237,7 +1237,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = BetterRail/BetterRailDebug.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
 				ENABLE_BITCODE = NO;
@@ -1280,7 +1280,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
 				INFOPLIST_FILE = BetterRail/Info.plist;
@@ -1452,7 +1452,7 @@
 				CODE_SIGN_ENTITLEMENTS = BetterRailWidgetExtensionDebug.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
@@ -1501,7 +1501,7 @@
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
@@ -1653,7 +1653,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = BetterRailWidgetExtensionDebug.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
@@ -1698,7 +1698,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
@@ -1736,7 +1736,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = StationIntent/StationIntentDebug.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;
@@ -1779,7 +1779,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UE6BVYPPFX;

--- a/ios/BetterRail/Info.plist
+++ b/ios/BetterRail/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/BetterRail/RNBetterRail.swift
+++ b/ios/BetterRail/RNBetterRail.swift
@@ -134,4 +134,13 @@ class RNBetterRail: NSObject {
       "frequentPushesEnabled": info.frequentPushesEnabled
     ])
   }
+  
+  @available(iOS 14.0, *)
+  @objc func isRunningOnMac(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
+    if ProcessInfo.processInfo.isiOSAppOnMac {
+      resolve(true)
+    } else {
+      resolve(false)
+    }
+  }
 }

--- a/ios/BetterRailWidget/Info.plist
+++ b/ios/BetterRailWidget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/BetterRailWidget/WatchInfo.plist
+++ b/ios/BetterRailWidget/WatchInfo.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/RNBetterRail.m
+++ b/ios/RNBetterRail.m
@@ -17,6 +17,6 @@ RCT_EXTERN_METHOD(isRideActive:(NSString *)rideId resolver:(RCTPromiseResolveBlo
 RCT_EXTERN_METHOD(monitorActivities)
 RCT_EXTERN_METHOD(reloadAllTimelines)
 RCT_EXTERN_METHOD(activityAuthorizationInfo:(NSString *)emptyString resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-
+RCT_EXTERN_METHOD(isRunningOnMac:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/StationIntent/Info.plist
+++ b/ios/StationIntent/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
The crash occurred because the live activities monitoring method initialized on the Mac app, where it's not available

Resolves #346 