### PR TITLE
Added snap interval to recent searches box

### DIFF
--- a/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
+++ b/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
@@ -29,6 +29,7 @@ const SCROLL_VIEW: ViewStyle = {
   minWidth: "100%",
   marginTop: spacing[3],
   paddingStart: spacing[3],
+  paddingEnd: spacing[4],
   gap: spacing[3],
 }
 

--- a/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
+++ b/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react"
-import { View, Image, TextStyle, ViewStyle, ImageStyle } from "react-native"
+import { View, Image, TextStyle, ViewStyle, ImageStyle, Platform } from "react-native"
 import { observer } from "mobx-react-lite"
 import { useStores } from "../../../models"
 import analytics from "@react-native-firebase/analytics"

--- a/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
+++ b/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
@@ -67,6 +67,7 @@ export const RecentSearchesBox = observer(function RecentSearchesBox(props: Rece
         showsHorizontalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={SCROLL_VIEW}
+        snapToInterval={175 + spacing[5]}
       >
         {sortedSearches.map((entry) => {
           // if a station is removed from stations list, it might still be in recent searches

--- a/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
+++ b/app/screens/select-station/recent-searches-box/recent-searches-box.tsx
@@ -67,7 +67,7 @@ export const RecentSearchesBox = observer(function RecentSearchesBox(props: Rece
         showsHorizontalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={SCROLL_VIEW}
-        snapToInterval={175 + spacing[5]}
+        snapToInterval={175 + spacing[3]}
       >
         {sortedSearches.map((entry) => {
           // if a station is removed from stations list, it might still be in recent searches


### PR DESCRIPTION
A small improvement for the recent searches box - now it snaps to the nearest item during scroll, instead of being (possibly) _[stuck in the middle](https://www.youtube.com/watch?v=ln7Vn_WKkWU)_.

https://github.com/better-rail/app/assets/13344923/f0991703-2d10-44e7-83db-2f70fc94524c



