### PR TITLE
Remove urgent messages upon viewing

### DIFF
--- a/app/components/announcements/announcement-card.tsx
+++ b/app/components/announcements/announcement-card.tsx
@@ -45,7 +45,7 @@ type AnnouncementCardProps = {
   title?: string
   body: string
   link?: string
-  type: "normal" | "notification"
+  type?: "normal" | "notification"
 }
 
 export const AnnouncementCard = ({ title, body, link, type }: AnnouncementCardProps) => (

--- a/app/components/announcements/urgent-announcements.tsx
+++ b/app/components/announcements/urgent-announcements.tsx
@@ -9,6 +9,7 @@ import { Screen } from "../screen/screen"
 import { useIsDarkMode } from "../../hooks"
 import { AnnouncementCard } from "./announcement-card"
 import { removeHtmlTagsAndEntities } from "./announcements-utils"
+import { uniqBy } from "lodash"
 
 export const UrgentAnnouncements = () => {
   const isDarkMode = useIsDarkMode()
@@ -18,8 +19,9 @@ export const UrgentAnnouncements = () => {
     <Screen unsafe statusBar={Platform.select({ ios: "light-content" })} statusBarBackgroundColor={isDarkMode ? "#000" : "#fff"}>
       <Text style={{ fontSize: 48, textAlign: "center", marginVertical: spacing[4] }}>📣</Text>
       <View style={{ paddingHorizontal: spacing[4] }}>
-        {messages?.map((message, index) => (
-          <AnnouncementCard body={message.messageBody} key={index} />
+        {/* we use uniqBy to avoid duplicate messages, as the API usually returns the same message twice */}
+        {uniqBy(unseenUrgentMessages, "title").map((message) => (
+          <AnnouncementCard body={message.messageBody} key={message.id} />
         ))}
       </View>
     </Screen>

--- a/app/components/announcements/urgent-announcements.tsx
+++ b/app/components/announcements/urgent-announcements.tsx
@@ -1,19 +1,32 @@
-import React from "react"
+import { useEffect, useState } from "react"
 import { Platform, View } from "react-native"
 import { useQuery } from "react-query"
+import { uniqBy } from "lodash"
 import { userLocale } from "../../i18n"
 import { PopUpMessage, railApi } from "../../services/api"
 import { spacing } from "../../theme"
-import { Text } from "../text/text"
-import { Screen } from "../screen/screen"
+import { Screen, Text } from ".."
 import { useIsDarkMode } from "../../hooks"
-import { AnnouncementCard } from "./announcement-card"
-import { removeHtmlTagsAndEntities } from "./announcements-utils"
-import { uniqBy } from "lodash"
+import { useStores } from "../../models"
 
 export const UrgentAnnouncements = () => {
+  const { settings } = useStores()
   const isDarkMode = useIsDarkMode()
+
   const { data: messages } = useQuery<PopUpMessage[]>(["announcements", "urgent"], () => railApi.getPopupMessages(userLocale))
+  const [unseenUrgentMessages, setUnseenUrgentMessages] = useState<PopUpMessage[]>([])
+
+  useEffect(() => {
+    const unseenUrgentMessages = settings.filterUnseenUrgentMessages(messages)
+    setUnseenUrgentMessages(unseenUrgentMessages)
+
+    if (unseenUrgentMessages) {
+      // Delay to avoid hiding the urgent announcement bar while the modal is opening
+      setTimeout(() => {
+        settings.setSeenUrgentMessagesIds(unseenUrgentMessages.map((message) => message.id))
+      }, 1000)
+    }
+  }, [messages])
 
   return (
     <Screen unsafe statusBar={Platform.select({ ios: "light-content" })} statusBarBackgroundColor={isDarkMode ? "#000" : "#fff"}>

--- a/app/components/announcements/urgent-announcements.tsx
+++ b/app/components/announcements/urgent-announcements.tsx
@@ -8,6 +8,7 @@ import { spacing } from "../../theme"
 import { Screen, Text } from ".."
 import { useIsDarkMode } from "../../hooks"
 import { useStores } from "../../models"
+import { AnnouncementCard } from "./announcement-card"
 
 export const UrgentAnnouncements = () => {
   const { settings } = useStores()
@@ -17,14 +18,17 @@ export const UrgentAnnouncements = () => {
   const [unseenUrgentMessages, setUnseenUrgentMessages] = useState<PopUpMessage[]>([])
 
   useEffect(() => {
-    const unseenUrgentMessages = settings.filterUnseenUrgentMessages(messages)
-    setUnseenUrgentMessages(unseenUrgentMessages)
+    if (messages) {
+      const unseenUrgentMessages = settings.filterUnseenUrgentMessages(messages)
+      setUnseenUrgentMessages(unseenUrgentMessages)
 
-    if (unseenUrgentMessages) {
-      // Delay to avoid hiding the urgent announcement bar while the modal is opening
-      setTimeout(() => {
-        settings.setSeenUrgentMessagesIds(unseenUrgentMessages.map((message) => message.id))
-      }, 1000)
+      if (unseenUrgentMessages.length > 0) {
+        // Delay to avoid hiding the urgent announcement bar while the modal is opening.
+        // For some reason, the timeout also prevents the rerender of planner screen header.
+        setTimeout(() => {
+          settings.setSeenUrgentMessagesIds(unseenUrgentMessages.map((message) => message.id))
+        }, 1000)
+      }
     }
   }, [messages])
 

--- a/app/models/settings/settings.ts
+++ b/app/models/settings/settings.ts
@@ -1,11 +1,13 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
 import { translate, TxKeyPath } from "../../i18n"
+import { PopUpMessage } from "../../services/api"
 
 export const SettingsModel = types
   .model("Settings")
   .props({
     stationsNotifications: types.optional(types.array(types.string), []),
     seenNotificationsScreen: types.optional(types.boolean, false),
+    seenUrgentMessagesIds: types.optional(types.array(types.number), []),
     profileCode: types.optional(types.number, 1),
     totalTip: types.optional(types.number, 0),
   })
@@ -39,6 +41,14 @@ export const SettingsModel = types
 
     addTip(amount: number) {
       self.totalTip = self.totalTip + amount
+    },
+  }))
+  .actions((self) => ({
+    setSeenUrgentMessagesIds(messagesIds: number[]) {
+      self.seenUrgentMessagesIds.replace(messagesIds)
+    },
+    filterUnseenUrgentMessages(messages: PopUpMessage[]) {
+      return messages.filter((message) => !self.seenUrgentMessagesIds.includes(message.id))
     },
   }))
 

--- a/app/screens/planner/planner-screen-header.tsx
+++ b/app/screens/planner/planner-screen-header.tsx
@@ -49,7 +49,7 @@ const SETTINGS_ICON = require("../../../assets/settings.png")
 type NavigationProps = StackNavigationProp<RootParamList, "mainStack">
 
 export const PlannerScreenHeader = observer(function PlannerScreenHeader() {
-  const { routePlan, ride } = useStores()
+  const { routePlan, ride, settings } = useStores()
   const navigation = useNavigation<NavigationProps>()
   const [displayNewBadge, setDisplayNewBadge] = useState(false)
 
@@ -57,7 +57,9 @@ export const PlannerScreenHeader = observer(function PlannerScreenHeader() {
     return railApi.getPopupMessages(userLocale)
   })
 
-  const showUrgentBar = !isEmpty(popupMessages)
+  // Filter unseen urgent messages from the popup messages
+  const unseenUrgentMessages = popupMessages ? settings.filterUnseenUrgentMessages(popupMessages) : []
+  const showUrgentBar = !isEmpty(unseenUrgentMessages)
 
   useEffect(() => {
     // display the "new" badge if the user has stations selected (not the initial launch),


### PR DESCRIPTION
- Added `seenUrgentMessagesIds` to the settings store
- Updated the `UrgentAnnouncements` component to support this property
- Added `uniqBy` to uregnt messages avoid duplicate messages provided by the API

The behaviour is after the user closes the urgent modal, the red bar will still be shown. It will be hidden upon re-opening the app.