### PR TITLE
Fix hours sheet RTL alignment

### DIFF
--- a/app/components/chip/chip.tsx
+++ b/app/components/chip/chip.tsx
@@ -3,7 +3,7 @@ import { color, fontScale, spacing } from "../../theme"
 
 const CHIP_WRAPPER: ViewStyle = {
   paddingHorizontal: spacing[3] * fontScale,
-  paddingVertical: spacing[0] + 1 * fontScale,
+  paddingVertical: (fontScale > 1 ? 1 : 0) * fontScale,
   flexDirection: "row",
   justifyContent: "center",
   alignItems: "center",

--- a/app/screens/route-list/components/station-hours-sheet.tsx
+++ b/app/screens/route-list/components/station-hours-sheet.tsx
@@ -88,11 +88,11 @@ export const StationHoursSheet = observer(
                 })}
               </ScrollView>
 
-              <View style={{ paddingHorizontal: spacing[4] }}>
+              <View style={{ paddingHorizontal: spacing[4], gap: spacing[1] }}>
                 {selectedGate.gateActivityHours
                   .filter((activityHour) => activityHour.activityHoursType === 1)
                   .map((activityHour) => (
-                    <View key={Math.random().toString(36)}>
+                    <View style={{ flexDirection: "column", alignItems: "flex-start" }} key={Math.random().toString(36)}>
                       <Text style={DAY_TEXT}>{convertDaysToAbbreviation(activityHour.activityDaysNumbers)}</Text>
                       <Text style={HOUR_TEXT}>
                         {activityHour.activityHoursReplaceTextKey ?? (


### PR DESCRIPTION
Beforehand the hours details were aligned to the left on RTL languages.

![IMAGE 2025-03-28 7:40:49 PM](https://github.com/user-attachments/assets/e34b3cfc-35f2-4934-aeee-c9ff9d4cee0b)
