### PR TITLE
Use correct destination when adding an exchange ride to calendar

### DIFF
--- a/app/components/route-details-header/route-details-header.tsx
+++ b/app/components/route-details-header/route-details-header.tsx
@@ -319,12 +319,7 @@ function createEventConfig(routeItem: RouteItem) {
 
   const origin = routeItem.trains[0].originStationName
   const trainNumber = routeItem.trains[0].trainNumber
-  let destination = routeItem.trains[0].destinationStationName
-
-  if (routeItem.trains.length > 1) {
-    // If there are multiple trains, we need to get the destination of the last train
-    destination = routeItem.trains[routeItem.trains.length - 1].destinationStationName
-  }
+  const destination = routeItem.trains[routeItem.trains.length - 1].destinationStationName
 
   const title = translate("plan.rideTo", { destination })
   const notes = translate("plan.trainFromToStation", { trainNumber, origin, destination })

--- a/app/components/route-details-header/route-details-header.tsx
+++ b/app/components/route-details-header/route-details-header.tsx
@@ -317,7 +317,15 @@ function createEventConfig(routeItem: RouteItem) {
     throw new Error("No trains found in routeItem")
   }
 
-  const { destinationStationName: destination, originStationName: origin, trainNumber } = routeItem.trains[0]
+  const origin = routeItem.trains[0].originStationName
+  const trainNumber = routeItem.trains[0].trainNumber
+  let destination = routeItem.trains[0].destinationStationName
+
+  if (routeItem.trains.length > 1) {
+    // If there are multiple trains, we need to get the destination of the last train
+    destination = routeItem.trains[routeItem.trains.length - 1].destinationStationName
+  }
+
   const title = translate("plan.rideTo", { destination })
   const notes = translate("plan.trainFromToStation", { trainNumber, origin, destination })
 


### PR DESCRIPTION
Previously, when adding a exchange-included ride to the calendar, we've used the first train destination. This change ensures we'll use the actual route destination, despite exchanges.