### PR TITLE
Change `BackHandler.removeEventListener` usage to `subscription.remove`

### DIFF
--- a/app/navigators/navigation-utilities.tsx
+++ b/app/navigators/navigation-utilities.tsx
@@ -77,10 +77,10 @@ export function useBackButtonHandler(ref: React.RefObject<NavigationContainerRef
     }
 
     // Subscribe when we come to life
-    BackHandler.addEventListener("hardwareBackPress", onBackPress)
+    const subscription = BackHandler.addEventListener("hardwareBackPress", onBackPress)
 
     // Unsubscribe when we're done
-    return () => BackHandler.removeEventListener("hardwareBackPress", onBackPress)
+    return () => subscription.remove()
   }, [ref])
 }
 

--- a/app/screens/route-list/components/station-hours-sheet.tsx
+++ b/app/screens/route-list/components/station-hours-sheet.tsx
@@ -69,7 +69,11 @@ export const StationHoursSheet = observer(
         subscription.remove()
       }
 
-      return () => subscription.remove()
+      return () => {
+        if (subscription) {
+          subscription.remove()
+        }
+      }
     }, [isOpen, onDone])
 
     return (

--- a/app/screens/route-list/components/station-hours-sheet.tsx
+++ b/app/screens/route-list/components/station-hours-sheet.tsx
@@ -55,6 +55,8 @@ export const StationHoursSheet = observer(
     }, [stationInfo])
 
     useEffect(() => {
+      let subscription: NativeEventSubscription | null = null
+
       const backHandler = () => {
         onDone()
         return true
@@ -62,12 +64,12 @@ export const StationHoursSheet = observer(
 
       if (isOpen) {
         // Prevents default back button behavior on Android
-        BackHandler.addEventListener("hardwareBackPress", backHandler)
+        subscription = BackHandler.addEventListener("hardwareBackPress", backHandler)
       } else {
-        BackHandler.removeEventListener("hardwareBackPress", backHandler)
+        subscription.remove()
       }
 
-      return () => BackHandler.removeEventListener("hardwareBackPress", backHandler)
+      return () => subscription.remove()
     }, [isOpen, onDone])
 
     return (

--- a/app/screens/route-list/components/station-hours-sheet.tsx
+++ b/app/screens/route-list/components/station-hours-sheet.tsx
@@ -65,7 +65,7 @@ export const StationHoursSheet = observer(
       if (isOpen) {
         // Prevents default back button behavior on Android
         subscription = BackHandler.addEventListener("hardwareBackPress", backHandler)
-      } else {
+      } else if (subscription) {
         subscription.remove()
       }
 


### PR DESCRIPTION
React Native v0.77 removes `BackHandler.removeEventListener` in exchange of `subscription.remove()` (https://github.com/facebook/react-native/pull/45892).

This prepares the app for the upcoming upgrade from v0.76. 

Also in this PR an upgrade for action sheet, which uses that method (https://github.com/expo/react-native-action-sheet/pull/339)