### PR TITLE
Update iOS live activity API URL to new production endpoint

### DIFF
--- a/ios/BetterRailWidget/Live Activity/ActivityNotificationsAPI.swift
+++ b/ios/BetterRailWidget/Live Activity/ActivityNotificationsAPI.swift
@@ -38,8 +38,7 @@ struct EndActivityResult: Decodable {
 }
 
 class ActivityNotificationsAPI {
-  static let envPath = LiveActivitiesController.env == "production" ? "" : "-test"
-  static let basePath = "https://better-rail\(envPath).up.railway.app/api/v1"
+  static let basePath = "https://api.better-rail.co.il/api/v1"
   
   static func startRide(ride: Ride) async -> String? {
       // Define the request URL


### PR DESCRIPTION
Forgot to update the API endpoint on the iOS live activity, making the calls not go through our Israeli proxy server in order to access the Israel Railways API.