### PR TITLE
Improve route details context menu labels

### DIFF
--- a/app/components/route-details-header/route-details-header.tsx
+++ b/app/components/route-details-header/route-details-header.tsx
@@ -191,8 +191,8 @@ export const RouteDetailsHeader = observer(function RouteDetailsHeader(props: Ro
         <ContextMenu
           dropdownMenuMode
           actions={[
-            { title: translate("routeDetails.addToCalendar"), systemIcon: "calendar" },
             { title: translate("routes.share"), systemIcon: "square.and.arrow.up" },
+            { title: translate("routeDetails.addToCalendar"), systemIcon: "calendar" },
             {
               title: translate(showEntireRoute ? "routeDetails.hideAllStations" : "routeDetails.showAllStations"),
               systemIcon: showEntireRoute ? "rectangle.compress.vertical" : "rectangle.expand.vertical",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -58,7 +58,7 @@
     "routeDetails": "Route Details",
     "routeActions": "Actions",
     "copyRoute": "Copy",
-    "share": "Share Ride Details",
+    "share": "Share Details",
     "routeCopied": "Copied to clipboard",
     "addedToCalendar": "Added to calendar"
   },
@@ -76,8 +76,8 @@
     "routeWarning": "Long Route Warning",
     "routeWarningText": "There are shorter train routes around the departure time.",
     "addToCalendar": "Add to Calendar",
-    "showAllStations": "Show all route stations",
-    "hideAllStations": "Hide all route stations",
+    "showAllStations": "Show Full Route",
+    "hideAllStations": "Hide Full Route",
     "noCalendarAccessTitle": "Calendar access disabled",
     "noCalendarAccessMessage": "To add the ride to your calendar, open your device settings and grant access to your calendar."
   },
@@ -239,7 +239,7 @@
     "connectionIssues": "Connection issues",
 
     "error": "An error occurred while starting the ride - please try to start a new ride.",
-    
+
     "notificationPermission1": "To receive real-time updates on the train's progress, please grant permission for us to send you notifications.",
     "notificationPermission2": "Our notification system is designed for efficiency, and we avoid sending unnecessary alerts.",
     "notificationPermission3": "Notifications",

--- a/app/i18n/he.json
+++ b/app/i18n/he.json
@@ -76,8 +76,8 @@
     "routeWarning": "רכבת מאספת",
     "routeWarningText": "קיימים מסלולי נסיעה קצרים יותר סביב שעת היציאה הנבחרת",
     "addToCalendar": "הוספה ליומן",
-    "showAllStations": "הצגת כל תחנות המסלול",
-    "hideAllStations": "הסתרת כל תחנות המסלול",
+    "showAllStations": "הצגת המסלול המלא",
+    "hideAllStations": "הסתרת המסלול המלא",
     "noCalendarAccessTitle": "גישה ללוח שנה כבויה",
     "noCalendarAccessMessage": "יש לאפשר גישה ללוח שנה בהגדרות המכשיר על מנת להוסיף נסיעה ליומן"
   },


### PR DESCRIPTION
Updates the English and Hebrew strings for the context menu to improve clarity & shorten labels. 

Also changed the action order, I feel it makes more sense in that order: communicate → plan → explore. Also, the icons feels like they point to the right direction now.

<img width="232" height="168" alt="Screenshot 2025-09-07 at 1 28 05 AM" src="https://github.com/user-attachments/assets/8c9e8837-b704-4848-a6c1-a3c8704035d4" />
