### PR TITLE
Improve Node.js detection in Xcode

### DIFF
--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -7,4 +7,21 @@
 # Customize the NODE_BINARY variable here.
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
-export NODE_BINARY=$(command -v node)
+
+# Try to load nvm if it exists, otherwise fall back to system node
+if [ -d "$HOME/.nvm" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+fi
+
+# Set NODE_BINARY, trying various common locations
+if command -v node >/dev/null 2>&1; then
+  export NODE_BINARY=$(command -v node)
+elif [ -x "/usr/local/bin/node" ]; then
+  export NODE_BINARY="/usr/local/bin/node"
+elif [ -x "/opt/homebrew/bin/node" ]; then
+  export NODE_BINARY="/opt/homebrew/bin/node"
+else
+  echo "Warning: Node.js not found. Please install Node.js or check your PATH."
+  export NODE_BINARY="node"
+fi


### PR DESCRIPTION
I had issues with building the project with xcode when I had NVM installed on my machine - got `Command PhaseScriptExecution failed with nonzero exit code` error.

These changes should improve `node` detection by xcode.