### PR TITLE
Fix: Application context not initialized crash

### DIFF
--- a/android/app/src/main/java/com/betterrail/widget/ModernBaseWidgetProvider.kt
+++ b/android/app/src/main/java/com/betterrail/widget/ModernBaseWidgetProvider.kt
@@ -226,6 +226,8 @@ abstract class ModernBaseWidgetProvider : AppWidgetProvider() {
     }
 
     private fun updateWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
+        applicationContext = context.applicationContext
+
         coroutineManager.launchInWidgetScope(appWidgetId) {
             val widgetData = preferencesRepository.getWidgetData(appWidgetId)
             


### PR DESCRIPTION
```
       Fatal Exception: java.lang.IllegalStateException: Application context not initialized
       at com.betterrail.widget.ModernBaseWidgetProvider.preferencesRepository_delegate$lambda$1(ModernBaseWidgetProvider.kt:54)
       at com.betterrail.widget.ModernBaseWidgetProvider.$r8$lambda$uUp3ArwhdOBKM5je1hp8plYLO-k()
       at com.betterrail.widget.ModernBaseWidgetProvider$$ExternalSyntheticLambda1.invoke(D8$$SyntheticClass)
       at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
       at com.betterrail.widget.ModernBaseWidgetProvider.getPreferencesRepository(ModernBaseWidgetProvider.kt:53)
       at com.betterrail.widget.ModernBaseWidgetProvider.access$getPreferencesRepository(ModernBaseWidgetProvider.kt:32)
       at com.betterrail.widget.ModernBaseWidgetProvider$updateWidget$1.invokeSuspend(ModernBaseWidgetProvider.kt:230)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
       at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
       at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
        
```