### PR TITLE
Fix: token null is not valid

### DIFF
--- a/android/app/src/main/java/com/betterrail/widget/BaseWidgetConfigActivity.kt
+++ b/android/app/src/main/java/com/betterrail/widget/BaseWidgetConfigActivity.kt
@@ -146,7 +146,7 @@ abstract class BaseWidgetConfigActivity : AppCompatActivity() {
         // Show dropdown when text field is focused or clicked
         originSearch.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                originSearch.showDropDown()
+                showDropdownSafely(originSearch)
             }
         }
         
@@ -185,7 +185,7 @@ abstract class BaseWidgetConfigActivity : AppCompatActivity() {
         // Show dropdown when text field is focused or clicked
         destinationSearch.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                destinationSearch.showDropDown()
+                showDropdownSafely(destinationSearch)
             }
         }
         
@@ -255,10 +255,16 @@ abstract class BaseWidgetConfigActivity : AppCompatActivity() {
         }
     }
     
-    private fun showDropdownWhenEmpty(autoCompleteTextView: AutoCompleteTextView) {
+    private fun showDropdownSafely(autoCompleteTextView: AutoCompleteTextView, delayMs: Long = 0) {
         autoCompleteTextView.postDelayed({
-            autoCompleteTextView.showDropDown()
-        }, 50)
+            if (autoCompleteTextView.isAttachedToWindow) {
+                autoCompleteTextView.showDropDown()
+            }
+        }, delayMs)
+    }
+
+    private fun showDropdownWhenEmpty(autoCompleteTextView: AutoCompleteTextView) {
+        showDropdownSafely(autoCompleteTextView, 50)
     }
     
     private fun updateAddButtonState() {


### PR DESCRIPTION
Repro:
- open the widget configuration screen
- tap on the field to give it focus
- rotate the device
- crash 💥 

Adding a null check before showing the dropdown, 

```
Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token null is 
not valid; is your activity running?
       at android.view.ViewRootImpl.setView(ViewRootImpl.java:2025)
       at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:578)
       at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:158)
       at android.widget.PopupWindow.invokePopup(PopupWindow.java:1712)
       at android.widget.PopupWindow.showAsDropDown(PopupWindow.java:1499)
       at android.widget.ListPopupWindow.show(ListPopupWindow.java:773)
       at android.widget.AutoCompleteTextView.showDropDown(AutoCompleteTextView.java:1332)
       at com.betterrail.widget.BaseWidgetConfigActivity.setupSearchListeners$lambda$4(BaseWidgetConfig
Activity.kt:149)
       at com.betterrail.widget.BaseWidgetConfigActivity.$r8$lambda$uHNlqsGV-B1ntLyV8zpXwYZtPlM()
       at com.betterrail.widget.BaseWidgetConfigActivity$ExternalSyntheticLambda5.onFocusChange(D8$Synt
heticClass)
       at android.view.View.onFocusChanged(View.java:9161)
       at android.widget.TextView.onFocusChanged(TextView.java:13779)
       at android.widget.AutoCompleteTextView.onFocusChanged(AutoCompleteTextView.java:1188)
       at android.view.View.handleFocusGainInternal(View.java:8817)
       at android.view.View.requestFocusNoSearch(View.java:15713)
       at android.view.View.requestFocus(View.java:15687)
       at android.view.View.requestFocus(View.java:15654)
       at android.view.View.requestFocus(View.java:15596)
       at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2399)
       at android.app.Activity.onRestoreInstanceState(Activity.java:2012)
       at android.app.Activity.performRestoreInstanceState(Activity.java:1965)
       at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1573)
       at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4514)
       at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecuto
r.java:270)
       at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:250)
       at 
android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:222)
       at 
android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:107)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:81)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2895)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loopOnce(Looper.java:257)
       at android.os.Looper.loop(Looper.java:342)
       at android.app.ActivityThread.main(ActivityThread.java:9634)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:619)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929) 
```