### PR TITLE
Notifications select stations screen to follow edge-to-edge pattern

### DIFF
--- a/app/screens/notifications/notifications-select-stations-screen.tsx
+++ b/app/screens/notifications/notifications-select-stations-screen.tsx
@@ -2,15 +2,16 @@ import { observer } from "mobx-react-lite"
 import { useState } from "react"
 
 import { Pressable, View } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { StationListItem } from "./station-list-item"
 import { color, fontScale, spacing } from "../../theme"
-import { Text } from "../../components"
+import { Screen, Text } from "../../components"
 import { useNavigation } from "@react-navigation/native"
 import { SearchInput } from "../select-station/search-input"
 import { translate } from "../../i18n"
 import { useStores } from "../../models"
 import HapticFeedback from "react-native-haptic-feedback"
-import { useFilteredStations } from "../../hooks"
+import { useFilteredStations, useIsDarkMode } from "../../hooks"
 import { useStations } from "../../data/stations"
 
 import { FlashList } from "@shopify/flash-list"
@@ -19,6 +20,7 @@ import { toJS } from "mobx"
 export const NotificationsSelectStationsScreen = observer(function NotificationsSelectStationsScreen() {
   const navigation = useNavigation()
   const [searchTerm, setSearchTerm] = useState("")
+  const insets = useSafeAreaInsets()
 
   const { settings } = useStores()
   const { stationsNotifications } = settings
@@ -27,6 +29,8 @@ export const NotificationsSelectStationsScreen = observer(function Notifications
   const { filteredStations } = useFilteredStations(searchTerm)
 
   const displayedStations = searchTerm === "" ? stations : filteredStations
+
+  const isDarkMode = useIsDarkMode()
 
   const onSelected = (stationId: string) => {
     HapticFeedback.trigger("impactLight")
@@ -40,44 +44,51 @@ export const NotificationsSelectStationsScreen = observer(function Notifications
   }
 
   return (
-    <View style={{ flex: 1, paddingHorizontal: spacing[3] }}>
-      <View
-        style={{
-          flexDirection: "row",
-          alignItems: "center",
-          marginTop: spacing[3],
-          marginBottom: spacing[2],
-          gap: spacing[3],
-        }}
-      >
-        <SearchInput searchTerm={searchTerm} setSearchTerm={setSearchTerm} autoFocus={false} />
-        <Pressable onPress={navigation.goBack}>
-          <Text style={{ color: color.primary }}>
-            {translate("common.done")} ({stationsNotifications.length})
-          </Text>
-        </Pressable>
-      </View>
+    <Screen
+      style={{ flex: 1 }}
+      unsafe={true}
+      statusBarBackgroundColor={isDarkMode ? "#000" : "#fff"}
+      translucent
+    >
+      <View style={{ flex: 1, paddingHorizontal: spacing[3], paddingTop: insets.top }}>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            marginTop: spacing[3],
+            marginBottom: spacing[2],
+            gap: spacing[3],
+          }}
+        >
+          <SearchInput searchTerm={searchTerm} setSearchTerm={setSearchTerm} autoFocus={false} />
+          <Pressable onPress={navigation.goBack}>
+            <Text style={{ color: color.primary }}>
+              {translate("common.done")} ({stationsNotifications.length})
+            </Text>
+          </Pressable>
+        </View>
 
-      <FlashList
-        data={displayedStations}
-        renderItem={({ item, extraData: selectedStations }) => {
-          return (
-            <StationListItem
-              title={item.name}
-              image={item.image}
-              selected={selectedStations.includes(item.id)}
-              onSelect={() => onSelected(item.id)}
-              style={{ marginBottom: spacing[3] }}
-            />
-          )
-        }}
-        keyExtractor={(item) => item.id}
-        showsVerticalScrollIndicator={false}
-        estimatedItemSize={76 * fontScale}
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: spacing[5] }}
-        extraData={toJS(stationsNotifications)}
-      />
-    </View>
+        <FlashList
+          data={displayedStations}
+          renderItem={({ item, extraData: selectedStations }) => {
+            return (
+              <StationListItem
+                title={item.name}
+                image={item.image}
+                selected={selectedStations.includes(item.id)}
+                onSelect={() => onSelected(item.id)}
+                style={{ marginBottom: spacing[3] }}
+              />
+            )
+          }}
+          keyExtractor={(item) => item.id}
+          showsVerticalScrollIndicator={false}
+          estimatedItemSize={76 * fontScale}
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: spacing[5] }}
+          extraData={toJS(stationsNotifications)}
+        />
+      </View>
+    </Screen>
   )
 })

--- a/app/screens/notifications/notifications-select-stations-screen.tsx
+++ b/app/screens/notifications/notifications-select-stations-screen.tsx
@@ -1,10 +1,10 @@
 import { observer } from "mobx-react-lite"
 import { useState } from "react"
 
-import { Pressable, View } from "react-native"
+import { Platform, Pressable, View } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { StationListItem } from "./station-list-item"
-import { color, fontScale, spacing } from "../../theme"
+import { color, spacing } from "../../theme"
 import { Screen, Text } from "../../components"
 import { useNavigation } from "@react-navigation/native"
 import { SearchInput } from "../select-station/search-input"
@@ -50,7 +50,7 @@ export const NotificationsSelectStationsScreen = observer(function Notifications
       statusBarBackgroundColor={isDarkMode ? "#000" : "#fff"}
       translucent
     >
-      <View style={{ flex: 1, paddingHorizontal: spacing[3], paddingTop: insets.top }}>
+      <View style={{ flex: 1, paddingHorizontal: spacing[3], paddingTop: Platform.OS === "android" ? insets.top : 0 }}>
         <View
           style={{
             flexDirection: "row",
@@ -83,7 +83,6 @@ export const NotificationsSelectStationsScreen = observer(function Notifications
           }}
           keyExtractor={(item) => item.id}
           showsVerticalScrollIndicator={false}
-          estimatedItemSize={76 * fontScale}
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: spacing[5] }}
           extraData={toJS(stationsNotifications)}


### PR DESCRIPTION
I've missed this screen on my previous edge-to-edge iteration, however, looks like it was broken both for android 14 and 15+ 

**Before** (Android 14 | Android 16)
<img width="1189" height="669" alt="image" src="https://github.com/user-attachments/assets/fd74eb23-f6ec-4f89-a19e-c99bbed06be6" />

**After** (Android 14 | Android 16)
<img width="1189" height="453" alt="image" src="https://github.com/user-attachments/assets/3b2c10b5-3cb0-4664-9aeb-6af351cd7a31" />
