### PR TITLE
fix(android): avoid Fabric mount crash when changing a route's station

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@react-native-masked-view/masked-view": "0.3.2",
         "@rnrepo/expo-config-plugin": "0.3.5",
         "@sentry/react-native": "8.16.0",
-        "@shopify/flash-list": "2.0.2",
+        "@shopify/flash-list": "2.3.2",
         "axios": "1.18.1",
         "babel-plugin-module-resolver": "5.0.3",
         "burnt": "0.12.2",
@@ -706,7 +706,7 @@
 
     "@sentry/replay-canvas": ["@sentry/replay-canvas@10.61.0", "", { "dependencies": { "@sentry/core": "10.61.0", "@sentry/replay": "10.61.0" } }, "sha512-n6QUN+qylEdKLcijpJsJ58ekY58kg0nG0dKxkD2wecKubl7B1mj/gwP35NmJOZ35vJTk/KbJeWB//finspJqYg=="],
 
-    "@shopify/flash-list": ["@shopify/flash-list@2.0.2", "", { "dependencies": { "tslib": "2.8.1" }, "peerDependencies": { "@babel/runtime": "*", "react": "*", "react-native": "*" } }, "sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w=="],
+    "@shopify/flash-list": ["@shopify/flash-list@2.3.2", "", { "peerDependencies": { "@babel/runtime": "*", "react": "*", "react-native": "*" } }, "sha512-vQnd0y0Ag11yzS30llaeCrtIU3xYTMe7KEOP3dveLImnVjQEUw6BEg1+Ztja6aODlVNz1BpvxtlQ5eZGxiLwKw=="],
 
     "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@react-native-masked-view/masked-view": "0.3.2",
     "@rnrepo/expo-config-plugin": "0.3.5",
     "@sentry/react-native": "8.16.0",
-    "@shopify/flash-list": "2.0.2",
+    "@shopify/flash-list": "2.3.2",
     "axios": "1.18.1",
     "babel-plugin-module-resolver": "5.0.3",
     "burnt": "0.12.2",

--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -27,6 +27,9 @@ import { HIDE_STATION_HOURS } from "@/config/features"
 const arrowIcon = require("../../../assets/arrow-left.png")
 const ellipsisIcon = require("../../../assets/ellipsis.regular.png")
 
+/** Longer than any stack dismiss animation, so it only ever fires if `transitionEnd` is missed. */
+const STATION_PICKER_FALLBACK_MS = 700
+
 export interface RouteDetailsHeaderProps {
   originId: string
   destinationId: string
@@ -59,6 +62,8 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   const routeEditDisabled = screenName !== "routeList"
 
   const stationCardScale = useRef(new RNAnimated.Value(1)).current
+  /** Set while the station picker is open, so we know a store change is arriving mid-transition. */
+  const awaitingStationPicker = useRef(false)
 
   const originName = stationsObject[originId][stationLocale]
   const destinationName = stationsObject[destinationId][stationLocale]
@@ -85,6 +90,8 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   const swapDirection = () => {
+    // This is an in-place change, so clear a flag left over from a picker the user cancelled.
+    awaitingStationPicker.current = false
     scaleStationCards()
     HapticFeedback.trigger("impactMedium")
     setTimeout(() => {
@@ -93,10 +100,12 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   const changeOriginStation = () => {
+    awaitingStationPicker.current = true
     router.push({ pathname: "/select-station", params: { selectionType: "origin" } })
   }
 
   const changeDestinationStation = () => {
+    awaitingStationPicker.current = true
     router.push({ pathname: "/select-station", params: { selectionType: "destination" } })
   }
 
@@ -124,15 +133,44 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     }
   }
 
+  // Only the route list reads its stations from the navigation params — route details and the
+  // active ride get theirs from the navigation params store, so syncing there writes params
+  // nobody reads (and would describe the planned route rather than the one being viewed).
   useEffect(() => {
-    if (routePlanOrigin?.id && routePlanDestination?.id) {
-      navigation.setParams({
-        originId: routePlanOrigin.id,
-        destinationId: routePlanDestination.id,
-      } as never)
+    if (routeEditDisabled) return
+
+    const nextOriginId = routePlanOrigin?.id
+    const nextDestinationId = routePlanDestination?.id
+    if (!nextOriginId || !nextDestinationId) return
+    if (nextOriginId === originId && nextDestinationId === destinationId) return
+
+    const applyParams = () => {
+      awaitingStationPicker.current = false
+      navigation.setParams({ originId: nextOriginId, destinationId: nextDestinationId } as never)
+    }
+
+    // Changed in place (the swap-direction button) — nothing is animating, apply right away.
+    if (!awaitingStationPicker.current) {
+      applyParams()
+      return
+    }
+
+    // The change came from the station picker, which writes to the store and pops itself in the
+    // same tick. Applying now rebuilds this whole screen (header image, route FlashList) while
+    // react-native-screens is still running the Android dismiss transition — Fabric then tries to
+    // mount a view that is still attached to the outgoing fragment and throws
+    // "addViewAt: failed to insert view [x] into parent [y]", killing the app or leaving a black
+    // screen. See software-mansion/react-native-screens#3249. Wait until we're back on top.
+    const unsubscribe = navigation.addListener("transitionEnd" as never, applyParams)
+    // Safety net: the params must never be dropped if `transitionEnd` doesn't arrive.
+    const fallback = setTimeout(applyParams, STATION_PICKER_FALLBACK_MS)
+
+    return () => {
+      unsubscribe()
+      clearTimeout(fallback)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routePlanOrigin?.id, routePlanDestination?.id])
+  }, [routePlanOrigin?.id, routePlanDestination?.id, originId, destinationId, routeEditDisabled])
 
   const renderHeaderRight = () => {
     if (screenName === "routeDetails") {

--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -30,8 +30,15 @@ const ellipsisIcon = require("../../../assets/ellipsis.regular.png")
 /** Longer than any stack dismiss animation, so it only ever fires if `transitionEnd` is missed. */
 const STATION_PICKER_FALLBACK_MS = 700
 
-/** `closing` is false when the screen has finished transitioning back to the top of the stack. */
 type TransitionEndEvent = { data?: { closing?: boolean } }
+
+/**
+ * react-native-screens reports `closing: false` once this screen has finished transitioning back
+ * to the top of the stack, and `closing: true` when it is being covered by one being pushed over
+ * it. Only the former means it is safe to mutate the screen. Anything else — including an event
+ * without the flag — is treated as "still moving", leaving the caller's timeout to catch it.
+ */
+const hasSettledOnTop = (event: TransitionEndEvent) => event.data?.closing === false
 
 export interface RouteDetailsHeaderProps {
   originId: string
@@ -137,15 +144,13 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   // The picker can also be dismissed without picking anything (Cancel, or the back gesture),
-  // which leaves no store change behind to clear the flag. Clear it whenever this screen has
-  // finished transitioning back to the top, so a later in-place change isn't needlessly deferred.
-  // Only on `closing: false` — a closing event means the picker is opening over us, which is
-  // exactly when the flag has to stay set.
+  // which leaves no store change behind to clear the flag. Clear it once this screen has settled
+  // back on top, so a later in-place change isn't needlessly deferred.
   useEffect(() => {
     if (routeEditDisabled) return
 
     return navigation.addListener("transitionEnd" as never, ((event: TransitionEndEvent) => {
-      if (!event.data?.closing) awaitingStationPicker.current = false
+      if (hasSettledOnTop(event)) awaitingStationPicker.current = false
     }) as never)
   }, [navigation, routeEditDisabled])
 
@@ -176,9 +181,13 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     // react-native-screens is still running the Android dismiss transition — Fabric then tries to
     // mount a view that is still attached to the outgoing fragment and throws
     // "addViewAt: failed to insert view [x] into parent [y]", killing the app or leaving a black
-    // screen. See software-mansion/react-native-screens#3249. Wait until we're back on top.
-    const unsubscribe = navigation.addListener("transitionEnd" as never, applyParams)
-    // Safety net: the params must never be dropped if `transitionEnd` doesn't arrive.
+    // screen. See software-mansion/react-native-screens#3249. Wait until we're back on top —
+    // and only then: if something else got pushed over this screen before the picker finished
+    // dismissing, that transition is just as unsafe to mutate during.
+    const unsubscribe = navigation.addListener("transitionEnd" as never, ((event: TransitionEndEvent) => {
+      if (hasSettledOnTop(event)) applyParams()
+    }) as never)
+    // Safety net: the params must never be dropped if no settled `transitionEnd` arrives.
     const fallback = setTimeout(applyParams, STATION_PICKER_FALLBACK_MS)
 
     return () => {

--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -27,17 +27,12 @@ import { HIDE_STATION_HOURS } from "@/config/features"
 const arrowIcon = require("../../../assets/arrow-left.png")
 const ellipsisIcon = require("../../../assets/ellipsis.regular.png")
 
-/** Longer than any stack dismiss animation, so it only ever fires if `transitionEnd` is missed. */
+/** Longer than any dismiss animation, so it only fires if `transitionEnd` is missed. */
 const STATION_PICKER_FALLBACK_MS = 700
 
 type TransitionEndEvent = { data?: { closing?: boolean } }
 
-/**
- * react-native-screens reports `closing: false` once this screen has finished transitioning back
- * to the top of the stack, and `closing: true` when it is being covered by one being pushed over
- * it. Only the former means it is safe to mutate the screen. Anything else — including an event
- * without the flag — is treated as "still moving", leaving the caller's timeout to catch it.
- */
+/** `closing: false` means this screen is back on top and done animating, so it's safe to mutate. */
 const hasSettledOnTop = (event: TransitionEndEvent) => event.data?.closing === false
 
 export interface RouteDetailsHeaderProps {
@@ -72,7 +67,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   const routeEditDisabled = screenName !== "routeList"
 
   const stationCardScale = useRef(new RNAnimated.Value(1)).current
-  /** Set while the station picker is open, so we know a store change is arriving mid-transition. */
+  /** Set while the station picker is open, so we know a store change came from it. */
   const awaitingStationPicker = useRef(false)
 
   const originName = stationsObject[originId][stationLocale]
@@ -100,7 +95,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   const swapDirection = () => {
-    // This is an in-place change, so clear a flag left over from a picker the user cancelled.
+    // In-place change — clear a flag left over from a cancelled picker.
     awaitingStationPicker.current = false
     scaleStationCards()
     HapticFeedback.trigger("impactMedium")
@@ -143,9 +138,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     }
   }
 
-  // The picker can also be dismissed without picking anything (Cancel, or the back gesture),
-  // which leaves no store change behind to clear the flag. Clear it once this screen has settled
-  // back on top, so a later in-place change isn't needlessly deferred.
+  // A cancelled picker leaves no store change behind to clear the flag, so clear it here instead.
   useEffect(() => {
     if (routeEditDisabled) return
 
@@ -154,9 +147,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     }) as never)
   }, [navigation, routeEditDisabled])
 
-  // Only the route list reads its stations from the navigation params — route details and the
-  // active ride get theirs from the navigation params store, so syncing there writes params
-  // nobody reads (and would describe the planned route rather than the one being viewed).
+  // Only the route list reads its stations from params — the other screens use the params store.
   useEffect(() => {
     if (routeEditDisabled) return
 
@@ -170,24 +161,19 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
       navigation.setParams({ originId: nextOriginId, destinationId: nextDestinationId } as never)
     }
 
-    // Changed in place (the swap-direction button) — nothing is animating, apply right away.
+    // In-place change (the swap button) — nothing is animating, apply right away.
     if (!awaitingStationPicker.current) {
       applyParams()
       return
     }
 
-    // The change came from the station picker, which writes to the store and pops itself in the
-    // same tick. Applying now rebuilds this whole screen (header image, route FlashList) while
-    // react-native-screens is still running the Android dismiss transition — Fabric then tries to
-    // mount a view that is still attached to the outgoing fragment and throws
-    // "addViewAt: failed to insert view [x] into parent [y]", killing the app or leaving a black
-    // screen. See software-mansion/react-native-screens#3249. Wait until we're back on top —
-    // and only then: if something else got pushed over this screen before the picker finished
-    // dismissing, that transition is just as unsafe to mutate during.
+    // The picker writes to the store and pops itself in the same tick. Applying now rebuilds this
+    // screen mid-transition, which crashes Fabric on Android with "addViewAt: failed to insert
+    // view" (react-native-screens#3249). Wait until we've settled instead.
     const unsubscribe = navigation.addListener("transitionEnd" as never, ((event: TransitionEndEvent) => {
       if (hasSettledOnTop(event)) applyParams()
     }) as never)
-    // Safety net: the params must never be dropped if no settled `transitionEnd` arrives.
+    // Safety net, so the params are never dropped.
     const fallback = setTimeout(applyParams, STATION_PICKER_FALLBACK_MS)
 
     return () => {

--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -30,6 +30,9 @@ const ellipsisIcon = require("../../../assets/ellipsis.regular.png")
 /** Longer than any stack dismiss animation, so it only ever fires if `transitionEnd` is missed. */
 const STATION_PICKER_FALLBACK_MS = 700
 
+/** `closing` is false when the screen has finished transitioning back to the top of the stack. */
+type TransitionEndEvent = { data?: { closing?: boolean } }
+
 export interface RouteDetailsHeaderProps {
   originId: string
   destinationId: string
@@ -132,6 +135,19 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
       await shareAction.onPress()
     }
   }
+
+  // The picker can also be dismissed without picking anything (Cancel, or the back gesture),
+  // which leaves no store change behind to clear the flag. Clear it whenever this screen has
+  // finished transitioning back to the top, so a later in-place change isn't needlessly deferred.
+  // Only on `closing: false` — a closing event means the picker is opening over us, which is
+  // exactly when the flag has to stay set.
+  useEffect(() => {
+    if (routeEditDisabled) return
+
+    return navigation.addListener("transitionEnd" as never, ((event: TransitionEndEvent) => {
+      if (!event.data?.closing) awaitingStationPicker.current = false
+    }) as never)
+  }, [navigation, routeEditDisabled])
 
   // Only the route list reads its stations from the navigation params — route details and the
   // active ride get theirs from the navigation params store, so syncing there writes params

--- a/src/screens/route-details/route-details-screen.tsx
+++ b/src/screens/route-details/route-details-screen.tsx
@@ -118,17 +118,15 @@ export function RouteDetailsScreen() {
       translucent
     >
       <View style={{ flex: 1 }}>
-        <Animated.View sharedTransitionTag="route-header">
-          <RouteDetailsHeader
-            routeItem={routeItem}
-            originId={originId}
-            destinationId={destinationId}
-            screenName={screenName}
-            showEntireRoute={showEntireRoute}
-            setShowEntireRoute={setShowEntireRoute}
-            style={styles.headerContainer}
-          />
-        </Animated.View>
+        <RouteDetailsHeader
+          routeItem={routeItem}
+          originId={originId}
+          destinationId={destinationId}
+          screenName={screenName}
+          showEntireRoute={showEntireRoute}
+          setShowEntireRoute={setShowEntireRoute}
+          style={styles.headerContainer}
+        />
 
         <View style={{ flex: 1 }}>
           <ScrollView

--- a/src/screens/route-list/route-list-screen.tsx
+++ b/src/screens/route-list/route-list-screen.tsx
@@ -3,7 +3,6 @@ import HapticFeedback from "react-native-haptic-feedback"
 import * as Burnt from "burnt"
 import { View, ActivityIndicator, Dimensions, useColorScheme } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
-import Animated from "react-native-reanimated"
 import { FlashList } from "@shopify/flash-list"
 import { useNetworkState } from "expo-network"
 import { useQuery } from "react-query"
@@ -490,14 +489,12 @@ export function RouteListScreen() {
       statusBarBackgroundColor="transparent"
       translucent
     >
-      <Animated.View sharedTransitionTag="route-header">
-        <RouteDetailsHeader
-          screenName="routeList"
-          originId={originId}
-          destinationId={destinationId}
-          style={{ paddingHorizontal: spacing[3], marginBottom: spacing[3] }}
-        />
-      </Animated.View>
+      <RouteDetailsHeader
+        screenName="routeList"
+        originId={originId}
+        destinationId={destinationId}
+        style={{ paddingHorizontal: spacing[3], marginBottom: spacing[3] }}
+      />
 
       {/* Only show the no internet error if we're not loading and there's no data */}
       {!isInternetReachable && !trains.isLoading && !trains.data && <RouteListError errorType="no-internet" />}


### PR DESCRIPTION
Fixes [BETTER-RAIL-37](https://better-rail.sentry.io/issues/7608260475/) (~4k events / 1.2k users, Android only) — picking a station in the picker wrote to the route plan store and popped the modal in the same tick, so the route list rebuilt underneath while react-native-screens was still running the Android dismiss transition, making Fabric mount a view still attached to the outgoing fragment and throw `addViewAt: failed to insert view` (see [react-native-screens#3249](https://github.com/software-mansion/react-native-screens/issues/3249)). The header now holds the param update until the screen's `transitionEnd` fires, with a timeout as a safety net, and the sync is scoped to the route list since route details and the active ride read their stations from the navigation params store instead. Also bumps FlashList to 2.3.2, which disables `removeClippedSubviews` on its ScrollView to prevent a sibling Android mounting crash, and drops the `sharedTransitionTag` wrappers, a no-op since Reanimated 4 removed shared element transitions.

Verified on a Pixel 9 Pro emulator: changing either station works, swap stays instant, cancel-then-swap works, and six rapid consecutive changes ran with no mounting errors in logcat. Note that I could not reproduce the original crash locally across ~30 attempts (including 10x-slowed transitions and rapid double-taps), so this is reasoned from the crash signature and the upstream bug rather than a red-to-green repro — worth watching the issue's event rate after release.