### PR TITLE
fix(android): freeze recent-search order so picking one can't blank the app

### DIFF
--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -27,14 +27,6 @@ import { HIDE_STATION_HOURS } from "@/config/features"
 const arrowIcon = require("../../../assets/arrow-left.png")
 const ellipsisIcon = require("../../../assets/ellipsis.regular.png")
 
-/** Longer than any dismiss animation, so it only fires if `transitionEnd` is missed. */
-const STATION_PICKER_FALLBACK_MS = 700
-
-type TransitionEndEvent = { data?: { closing?: boolean } }
-
-/** `closing: false` means this screen is back on top and done animating, so it's safe to mutate. */
-const hasSettledOnTop = (event: TransitionEndEvent) => event.data?.closing === false
-
 export interface RouteDetailsHeaderProps {
   originId: string
   destinationId: string
@@ -67,11 +59,13 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   const routeEditDisabled = screenName !== "routeList"
 
   const stationCardScale = useRef(new RNAnimated.Value(1)).current
-  /** Set while the station picker is open, so we know a store change came from it. */
-  const awaitingStationPicker = useRef(false)
 
-  const originName = stationsObject[originId][stationLocale]
-  const destinationName = stationsObject[destinationId][stationLocale]
+  // A station can outlive its entry in `stations.ts` — it may still sit in a favorite route, a
+  // recent search or a deep link. Reading it blindly throws and takes the whole screen down.
+  const originStation = stationsObject[originId]
+  const destinationStation = stationsObject[destinationId]
+  const originName = originStation?.[stationLocale]
+  const destinationName = destinationStation?.[stationLocale]
   const routeId = `${originId}${destinationId}`
   const isFavorite = favoriteRoutesData.some((fav) => fav.id === routeId)
 
@@ -95,8 +89,6 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   const swapDirection = () => {
-    // In-place change — clear a flag left over from a cancelled picker.
-    awaitingStationPicker.current = false
     scaleStationCards()
     HapticFeedback.trigger("impactMedium")
     setTimeout(() => {
@@ -105,12 +97,10 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   const changeOriginStation = () => {
-    awaitingStationPicker.current = true
     router.push({ pathname: "/select-station", params: { selectionType: "origin" } })
   }
 
   const changeDestinationStation = () => {
-    awaitingStationPicker.current = true
     router.push({ pathname: "/select-station", params: { selectionType: "destination" } })
   }
 
@@ -138,15 +128,6 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     }
   }
 
-  // A cancelled picker leaves no store change behind to clear the flag, so clear it here instead.
-  useEffect(() => {
-    if (routeEditDisabled) return
-
-    return navigation.addListener("transitionEnd" as never, ((event: TransitionEndEvent) => {
-      if (hasSettledOnTop(event)) awaitingStationPicker.current = false
-    }) as never)
-  }, [navigation, routeEditDisabled])
-
   // Only the route list reads its stations from params — the other screens use the params store.
   useEffect(() => {
     if (routeEditDisabled) return
@@ -156,30 +137,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     if (!nextOriginId || !nextDestinationId) return
     if (nextOriginId === originId && nextDestinationId === destinationId) return
 
-    const applyParams = () => {
-      awaitingStationPicker.current = false
-      navigation.setParams({ originId: nextOriginId, destinationId: nextDestinationId } as never)
-    }
-
-    // In-place change (the swap button) — nothing is animating, apply right away.
-    if (!awaitingStationPicker.current) {
-      applyParams()
-      return
-    }
-
-    // The picker writes to the store and pops itself in the same tick. Applying now rebuilds this
-    // screen mid-transition, which crashes Fabric on Android with "addViewAt: failed to insert
-    // view" (react-native-screens#3249). Wait until we've settled instead.
-    const unsubscribe = navigation.addListener("transitionEnd" as never, ((event: TransitionEndEvent) => {
-      if (hasSettledOnTop(event)) applyParams()
-    }) as never)
-    // Safety net, so the params are never dropped.
-    const fallback = setTimeout(applyParams, STATION_PICKER_FALLBACK_MS)
-
-    return () => {
-      unsubscribe()
-      clearTimeout(fallback)
-    }
+    navigation.setParams({ originId: nextOriginId, destinationId: nextDestinationId } as never)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routePlanOrigin?.id, routePlanDestination?.id, originId, destinationId, routeEditDisabled])
 
@@ -344,7 +302,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   return (
     <>
       <ImageBackground
-        source={stationsObject[originId].image}
+        source={originStation?.image}
         style={{
           width: "100%",
           height: screenName !== "activeRide" ? 200 : 155,

--- a/src/screens/route-list/route-list-screen.tsx
+++ b/src/screens/route-list/route-list-screen.tsx
@@ -141,14 +141,8 @@ export function RouteListScreen() {
   // Keep track of the dates we've already loaded
   const [loadedDates, setLoadedDates] = useState<Set<string>>(new Set())
 
-  // The station pair `routeData` belongs to. We replace the data once the new routes arrive
-  // instead of emptying it here, since unmounting the FlashList mid-transition crashes Fabric.
-  // Kept in state rather than a ref because rendering needs it: while the new pair loads the old
-  // routes stay on screen, and a card tapped in that window must carry the stations it was
-  // actually fetched for, not the ones now showing in the header.
-  const [routeDataStations, setRouteDataStations] = useState({ originId, destinationId })
-
   useEffect(() => {
+    setRouteData([])
     setLoadedDates(new Set())
   }, [originId, destinationId])
 
@@ -278,29 +272,13 @@ export function RouteListScreen() {
       // Create a new date string for the current date
       const dateString = currentDate.toDateString()
 
-      // Routes for a different station pair replace the old ones instead of merging with them
-      const stationsChanged = routeDataStations.originId !== originId || routeDataStations.destinationId !== destinationId
-      if (stationsChanged) setRouteDataStations({ originId, destinationId })
-
       // Organize routes by date
       setRouteData((prevData) => {
-        const newData = organizeRoutesByDate(trains.data, dateString, stationsChanged ? [] : prevData)
+        const newData = organizeRoutesByDate(trains.data, dateString, prevData)
         return newData
       })
     }
-
-    // The old routes stay on screen while the new pair loads, but if the query fails they have to
-    // go — otherwise they sit under the new stations forever, and neither the empty nor the error
-    // state appears, since both are gated on `routeData` being empty.
-    if (trains.isError) {
-      if (routeDataStations.originId !== originId || routeDataStations.destinationId !== destinationId) {
-        setRouteDataStations({ originId, destinationId })
-        setRouteData([])
-        updateResultType("not-found")
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trains.data, currentDate, trains.isSuccess, trains.isLoading, trains.isError, originId, destinationId])
+  }, [trains.data, currentDate, trains.isSuccess, trains.isLoading, updateResultType])
 
   // Initialize the loaded dates with the initial date
   useEffect(() => {
@@ -415,7 +393,7 @@ export function RouteListScreen() {
               break
 
             case 1: // Share
-              await shareRouteAction(routeItem, routeDataStations.originId, routeDataStations.destinationId)
+              await shareRouteAction(routeItem, originId, destinationId)
               break
 
             default:
@@ -482,13 +460,13 @@ export function RouteListScreen() {
         isActiveRide={isRouteActive(item)}
         isRouteInThePast={isRouteInThePast(arrivalTime, item.delay)}
         onPress={() => {
-          useNavigationParamsStore.getState().setRouteDetails({ routeItem: item, ...routeDataStations })
+          useNavigationParamsStore.getState().setRouteDetails({ routeItem: item, originId, destinationId })
           router.push("/route-details")
         }}
         onLongPress={() => handleRouteLongPress(item)}
         routeItem={item}
-        originId={routeDataStations.originId}
-        destinationId={routeDataStations.destinationId}
+        originId={originId}
+        destinationId={destinationId}
         shouldShowDashedLine={shouldShowDashedLine}
         style={{ marginBottom: spacing[3] }}
       />

--- a/src/screens/select-station/recent-searches-box/recent-searches-box.tsx
+++ b/src/screens/select-station/recent-searches-box/recent-searches-box.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef } from "react"
 import { View, Image, Platform } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
 import { useShallow } from "zustand/react/shallow"
@@ -24,7 +24,17 @@ export function RecentSearchesBox(props: RecentSearchesBoxProps) {
     useShallow((s) => ({ entries: s.entries, save: s.save, remove: s.remove })),
   )
 
-  const sortedSearches = [...entries].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 6)
+  // Rank by recency once per mount — the new order only shows the next time the picker opens.
+  // Picking an entry bumps its `updatedAt` and pops the screen in the same commit, and Fabric on
+  // Android can't mount a re-sort inside a subtree that same commit is deleting: it throws
+  // "addViewAt: cannot insert view […] View already has a parent" and blanks the app.
+  const initialRankRef = useRef<Map<string, number> | null>(null)
+  const initialRank = (initialRankRef.current ??= new Map(
+    [...entries].sort((a, b) => b.updatedAt - a.updatedAt).map((entry, index) => [entry.id, index]),
+  ))
+
+  const rankOf = (id: string) => initialRank.get(id) ?? Number.MAX_SAFE_INTEGER
+  const sortedSearches = [...entries].sort((a, b) => rankOf(a.id) - rankOf(b.id)).slice(0, 6)
 
   const onStationPress = (entry) => {
     trackEvent("recent_station_selected")


### PR DESCRIPTION
## The bug

Changing a station could leave the app on a **blank white screen** on Android — alive, but dead until force-quit. A user hit it again today and sent a video; #688 and #689 both tried to fix it and didn't.

## Root cause

`RecentSearchesBox.onStationPress` calls `save({ id })` — which bumps the entry's `updatedAt`, so the tapped card jumps to the front of the recency sort — and `router.back()` **in the same tick**. React batches both into one commit, so Fabric has to reorder a card *inside a subtree that same commit is deleting*:

```
REMOVE [832]->[846] @1
INSERT [832]->[846] @0     ← throws: view already has parent [846]
... (rest of the batch tears down the select-station subtree)

java.lang.IllegalStateException: addViewAt: cannot insert view [832] into parent [846]
Caused by: The specified child already has a parent...
  at ReactClippingViewManager.addView
ReactHost{0}.handleHostException(...)   ← tears down the surface → blank screen
```

The REMOVE no-ops on a stale index and the INSERT then throws.

Tapping the recent that is **already first** (no reorder) is fine; tapping any other one crashes, every time. It reproduces straight from the planner — no route list, no station params involved — which is why the two earlier attempts, both aimed at the route-list header, missed it. Android-only, since it's an Android Fabric mounting bug.

## The fix

Rank the recent searches **once per mount**, so picking one moves nothing on screen; the new order shows the next time the picker opens. `entries` stays the render source, so hiding an entry still updates the row immediately. Deferring `save()` would not help — the screen stays mounted through the dismiss animation, so it would just move the same bad commit later.

## Also in here

- **Reverts #688 and #689.** The deferred `setParams` (`awaitingStationPicker` ref + `transitionEnd` listeners + a 700 ms fallback) and the `routeDataStations` bookkeeping in the route list were both workarounds for this crash from the wrong end. Their genuine improvements are kept: the `routeEditDisabled` / id-equality guards on the params effect, and the `sharedTransitionTag` removals. Net **+27 / −81**.
- **Guards the header's station lookups.** `stationsObject[originId][stationLocale]` and `.image` threw `Cannot convert undefined value to object` for any id no longer in `stations.ts` — a stale favorite, recent search or deep link — dropping the app on the error screen. Now renders an empty pill instead.

## Testing

Android (Pixel 9 Pro emulator, debug build) — `addViewAt` / `already has a parent` count in logcat is **0** for all of:

- planner → picker → tap a non-first recent
- route list → picker → tap a non-first recent (routes clear and reload correctly with #689 reverted)
- swap-direction button
- Hebrew/RTL, with the Saturday "no trains at the requested hour" banner up — i.e. the exact flow from the user's video
- header guard: forced a missing-station lookup → header renders with an empty origin pill and no background image, screen still fully functional, no crash

iOS (iPhone 17 Pro simulator) — the two paths this touches beyond the Android crash:

- long-press a recent → Hide → row updates immediately (this `remove` path is iOS-only)
- route-list station change → header updates, routes reload

`tsc` error count unchanged vs. baseline, oxlint clean on the touched files, oxfmt clean, 33/33 tests pass.

## Known, not addressed here

The same unguarded `stationsObject[...]` reads still exist in `favorites.ts`, `route-details.tsx` and `favorite-route-box.tsx` — same latent crash class, left for a separate change.