### PR TITLE
fix(ios): disable rnrepo iOS prebuilds to unblock local production builds

### DIFF
--- a/rnrepo.config.json
+++ b/rnrepo.config.json
@@ -1,6 +1,10 @@
 {
-  "//": "Libraries we patch must build from source — a prebuilt artifact is built upstream and would drop the patch.",
+  "//": "Patched libraries must build from source — prebuilts are built upstream and drop the patch.",
   "denyList": {
     "android": ["react-native-screens"]
+  },
+  "//ios": "No iOS prebuilts: rnrepo injects RNWorklets' modulemap into ExpoModulesCore without a target dependency, racing [CP] Copy XCFrameworks.",
+  "allowList": {
+    "ios": []
   }
 }


### PR DESCRIPTION
## Problem

`eas build --profile production --platform ios --local` fails at `** ARCHIVE FAILED **` with hundreds of:

```
module map file '.../XCFrameworkIntermediates/RNWorklets/worklets.framework/Modules/module.modulemap' not found
  (in target 'ExpoModulesCore' from project 'Pods')
```

followed by cascading `Compilation search paths unable to resolve module dependency: 'ExpoModulesCore' / 'React' / 'CommonCrypto'`, plus a separate `❌ Script '[CP] Copy XCFrameworks' failed └─ Pods/RNSVG`.

## Cause

`@rnrepo/build-tools`' CocoaPods plugin appends a raw `-fmodule-map-file=$(PODS_XCFRAMEWORKS_BUILD_DIR)/RNWorklets/.../module.modulemap` to `ExpoModulesCore`'s `OTHER_CFLAGS` / `OTHER_SWIFT_FLAGS`, but never creates a target dependency on `RNWorklets`. Xcode is free to compile `ExpoModulesCore` before `RNWorklets`' `[CP] Copy XCFrameworks` phase has produced that file — and it does. The build log confirms the ordering: the modulemap errors appear *before* `Executing react-native-worklets Pods/RNWorklets » [CP] Copy XCFrameworks`.

The log also warned about the injected phases: `Script has ambiguous dependencies causing it to run on every build … Pods/RNSVG-RNSVGFilters » '[AA RUN FIRST] RNREPO Build Start'`.

## Fix

Add an empty `allowList.ios`, which disables iOS prebuilds entirely:

- The plugin's deny/allow mutual-exclusion check is **per-platform**, so `denyList.android` + `allowList.ios` is valid.
- With nothing prebuilt, `Pod::Installer.prebuilt_rnrepo_pods` stays `[]`, so the `RNWorklets` lookup returns nil and the modulemap flags are never injected — and no `[AA RUN FIRST]` phases are added either.
- Android behavior is unchanged.

### Why not a targeted `denyList.ios`

Denying only `react-native-worklets` + `react-native-svg` would leave `RNReanimated` on a prebuilt while worklets built from source (version-skew risk), and wouldn't prevent the next copy-phase race.

### Cost

Small — only 7 of 38 iOS pods resolved to prebuilts (18.4%), the rest 404'd, and two of those seven were the ones breaking the build.

Worth revisiting if rnrepo fixes the `ExpoModulesCore` / worklets ordering upstream.

## Testing

Run without any env flag:

```
eas build --profile production --platform ios --local
```

https://claude.ai/code/session_01WoHFGk1b37CdiKaVZwnVRW