### PR TITLE
chore: bump app version to 2.7.9

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.8",
+  version: "2.7.9",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },


### PR DESCRIPTION
Bumps the app version from 2.7.8 to 2.7.9 in `app.config.ts`.

`ios.buildNumber` and `android.versionCode` are unchanged.

https://claude.ai/code/session_01DRkyP8DkvdLkM7EogcraBs