### PR TITLE
fix(watch): set watch app display name to 'Better Rail'

### DIFF
--- a/targets/watch/Info.plist
+++ b/targets/watch/Info.plist
@@ -4,16 +4,6 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>Better Rail</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionAttributes</key>
-		<dict>
-			<key>WKAppBundleIdentifier</key>
-			<string>il.co.better-rail.watchkitapp</string>
-		</dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/targets/watch/expo-target.config.js
+++ b/targets/watch/expo-target.config.js
@@ -8,6 +8,7 @@
 module.exports = {
   type: "watch",
   name: "BetterRailWatch",
+  displayName: "Better Rail",
   bundleIdentifier: ".watchkitapp",
   deploymentTarget: "9.0",
   frameworks: ["SwiftUI"],


### PR DESCRIPTION
Sets `displayName` on the watchOS target so the app shows as **Better Rail** on the watch home screen instead of `BetterRailWatch`.