### PR TITLE
chore: upgrade posthog and remove session replay

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.9",
+  version: "2.7.10",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },

--- a/bun.lock
+++ b/bun.lock
@@ -44,8 +44,7 @@
         "fuse.js": "6.4.6",
         "i18n-js": "3.8.0",
         "lodash": "4.18.1",
-        "posthog-react-native": "^4.39.4",
-        "posthog-react-native-session-replay": "^1.5.2",
+        "posthog-react-native": "^4.66.2",
         "ramda": "0.27.1",
         "react": "19.2.3",
         "react-native": "0.85.3",
@@ -551,7 +550,9 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@posthog/core": ["@posthog/core@1.24.6", "", {}, "sha512-9WkcRKqmXSWIJcca6m3VwA9YbFd4HiG2hKEtDq6FcwEHlvfDhQQUZ5/sJZ47Fw8OtyNMHQ6rW4+COttk4Bg5NQ=="],
+    "@posthog/core": ["@posthog/core@1.49.2", "", { "dependencies": { "@posthog/types": "^1.407.1" } }, "sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg=="],
+
+    "@posthog/types": ["@posthog/types@1.407.1", "", {}, "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
@@ -1545,9 +1546,7 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "posthog-react-native": ["posthog-react-native@4.39.4", "", { "dependencies": { "@posthog/core": "1.24.6" }, "peerDependencies": { "@react-native-async-storage/async-storage": ">=1.0.0", "@react-navigation/native": ">= 5.0.0", "expo-application": ">= 4.0.0", "expo-device": ">= 4.0.0", "expo-file-system": ">= 13.0.0", "expo-localization": ">= 11.0.0", "posthog-react-native-session-replay": ">= 1.5.2", "react-native-device-info": ">= 10.0.0", "react-native-localize": ">= 3.0.0", "react-native-navigation": ">= 6.0.0", "react-native-safe-area-context": ">= 4.0.0", "react-native-svg": ">= 15.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "@react-navigation/native", "expo-application", "expo-device", "expo-file-system", "expo-localization", "posthog-react-native-session-replay", "react-native-device-info", "react-native-localize", "react-native-navigation", "react-native-safe-area-context"] }, "sha512-5R1HEOoSimuEKGOP+0sni939VyIniRyFkT+Lxl2btKLSy+FKzfIREYGkyADTpNOJmKxiFVHuOgDHj3iY6l+7Ww=="],
-
-    "posthog-react-native-session-replay": ["posthog-react-native-session-replay@1.5.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NS/HbEOp9NQSkL99pNmkCSprLV42SHgEv7uUvCNeWByG1TG4MUMzk83U3n3V5odENphNQvkYPChRKneiKourPQ=="],
+    "posthog-react-native": ["posthog-react-native@4.66.2", "", { "dependencies": { "@posthog/core": "^1.49.2", "@posthog/types": "^1.407.1" }, "peerDependencies": { "@posthog/react-native-plugin": ">= 2.4.3", "@react-native-async-storage/async-storage": ">=1.0.0", "@react-navigation/native": ">= 5.0.0", "expo-application": ">= 4.0.0", "expo-device": ">= 4.0.0", "expo-file-system": ">= 13.0.0", "expo-localization": ">= 11.0.0", "posthog-react-native-session-replay": ">= 1.6.0", "react-native-device-info": ">= 10.0.0", "react-native-localize": ">= 3.0.0", "react-native-navigation": ">= 6.0.0", "react-native-safe-area-context": ">= 4.0.0", "react-native-svg": ">= 15.0.0" }, "optionalPeers": ["@posthog/react-native-plugin", "@react-native-async-storage/async-storage", "@react-navigation/native", "expo-application", "expo-device", "expo-file-system", "expo-localization", "posthog-react-native-session-replay", "react-native-device-info", "react-native-localize", "react-native-navigation", "react-native-safe-area-context", "react-native-svg"], "bin": { "posthog-react-native-xcode": "tooling/posthog-xcode.sh" } }, "sha512-fQlrIK6Qj+Y8DI2Vmwfr/iu9GXxjoTNUdQ0dXXA9AiIbmubI8a4QWbceOQXTAmkGY1cLdvCmn/QqV2UZB3XWQw=="],
 
     "postinstall-prepare": ["postinstall-prepare@1.0.1", "", {}, "sha512-4zxO4DjrV0XfD+ABUFEP0MiQmhKOGBnov5LfLsra/XVOUcQ5gMLLMcV3b8K8wJUfNDv1ozleGblYb06gPbjVUQ=="],
 

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "fuse.js": "6.4.6",
     "i18n-js": "3.8.0",
     "lodash": "4.18.1",
-    "posthog-react-native": "^4.39.4",
-    "posthog-react-native-session-replay": "^1.5.2",
+    "posthog-react-native": "^4.66.2",
     "ramda": "0.27.1",
     "react": "19.2.3",
     "react-native": "0.85.3",
@@ -159,7 +158,6 @@
           "react-native-push-notification",
           "react-native-default-preference",
           "@notifee/react-native",
-          "posthog-react-native-session-replay",
           "react-native-prompt-android",
           "react-native-quick-actions-shortcuts"
         ]

--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -11,7 +11,6 @@ export const posthogOptions: PostHogOptions = {
   host: "https://eu.i.posthog.com",
   persistence: "file" as const,
   customStorage: AsyncStorage,
-  enableSessionReplay: false,
 }
 
 // Inlined into the JS bundle by babel-preset-expo (EXPO_PUBLIC_* prefix). Available in EAS
@@ -26,7 +25,7 @@ const POSTHOG_API_KEY = process.env.EXPO_PUBLIC_POSTHOG_API_KEY
 // disabled client (placeholder key passes the falsy check; `disabled` makes it a no-op).
 export const posthog = POSTHOG_API_KEY
   ? new PostHog(POSTHOG_API_KEY, posthogOptions)
-  : new PostHog("phc_disabled_placeholder", { ...posthogOptions, enableSessionReplay: false, disabled: true })
+  : new PostHog("phc_disabled_placeholder", { ...posthogOptions, disabled: true })
 
 type AnalyticsParams = Record<string, string | number | boolean | null | undefined>
 


### PR DESCRIPTION
Bumps posthog-react-native to 4.66.2 and drops `posthog-react-native-session-replay` — session recording is no longer used, so the native module isn't needed.