### PR TITLE
fix: increase Gradle JVM heap and metaspace for release builds

### DIFF
--- a/plugins/withBetterRailAndroid/withAndroidGradleProperties.js
+++ b/plugins/withBetterRailAndroid/withAndroidGradleProperties.js
@@ -16,7 +16,7 @@ const withAndroidGradleProperties = (config) =>
     upsert("android.useAndroidX", "true")
     upsert("android.enableJetifier", "true")
     // Jetifier needs more heap to transform large AARs like react-android.aar.
-    upsert("org.gradle.jvmargs", "-Xmx4096m -XX:MaxMetaspaceSize=512m")
+    upsert("org.gradle.jvmargs", "-Xmx6144m -XX:MaxMetaspaceSize=1536m")
     return cfg
   })
 


### PR DESCRIPTION
## Summary
Local EAS Android production builds fail with `OutOfMemoryError: Metaspace` in `:expo-updates:kspReleaseKotlin` and several `lintVitalAnalyzeRelease` tasks. Gradle's own warning flags the 512 MiB metaspace cap as insufficient.

Bumps `org.gradle.jvmargs` in the Android config plugin from `-Xmx4096m -XX:MaxMetaspaceSize=512m` to `-Xmx6144m -XX:MaxMetaspaceSize=1536m`.

## Test plan
- [ ] `eas build --profile production --platform android --local` completes

https://claude.ai/code/session_01JitcpziuPZcfREEifag8RR