### PR TITLE
chore: remove Patreon sponsor from funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-patreon: BetterRail


### PR DESCRIPTION
Removes the `patreon: BetterRail` entry from `.github/FUNDING.yml`, so the GitHub Sponsor button no longer points to Patreon. The file is now empty rather than deleted — let me know if it should be removed entirely.