### PR TITLE
fix(ios): backport Expo SDK 57 RuntimeScheduler fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,13 +103,14 @@
     },
   },
   "patchedDependencies": {
+    "react-native-modal-datetime-picker@18.0.0": "patches/react-native-modal-datetime-picker@18.0.0.patch",
     "react-native-watch-connectivity@1.1.0": "patches/react-native-watch-connectivity@1.1.0.patch",
     "expo-modules-core@56.0.17": "patches/expo-modules-core@56.0.17.patch",
     "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch",
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
     "react-native-quick-actions-shortcuts@1.0.2": "patches/react-native-quick-actions-shortcuts@1.0.2.patch",
     "react-native-push-notification@8.1.1": "patches/react-native-push-notification@8.1.1.patch",
-    "react-native-modal-datetime-picker@18.0.0": "patches/react-native-modal-datetime-picker@18.0.0.patch",
+    "expo@56.0.12": "patches/expo@56.0.12.patch",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "react-native-push-notification@8.1.1": "patches/react-native-push-notification@8.1.1.patch",
     "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch",
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
-    "expo-modules-core@56.0.17": "patches/expo-modules-core@56.0.17.patch"
+    "expo-modules-core@56.0.17": "patches/expo-modules-core@56.0.17.patch",
+    "expo@56.0.12": "patches/expo@56.0.12.patch"
   }
 }

--- a/patches/expo-modules-core@56.0.17.patch
+++ b/patches/expo-modules-core@56.0.17.patch
@@ -23,14 +23,21 @@ index 1188204ab9d08d0f60f8b0fd9b149f97861a967b..63c4a9c7d8a9ccf6f847728696e8f9ad
      return try Conversions.unknownToJavaScriptValue(value, appContext: appContext)
    }
 diff --git a/ios/JS/EXReactSchedulerDispatch.h b/ios/JS/EXReactSchedulerDispatch.h
-index c390ad2b915474ae8cef02edcc6cecb45dd507ce..0b62004b9c2ddb1861376fbc3c39defa9366b80a 100644
+index c390ad2b915474ae8cef02edcc6cecb45dd507ce..3a35683e4481c647f807e3e9fe098c718dace0e5 100644
 --- a/ios/JS/EXReactSchedulerDispatch.h
 +++ b/ios/JS/EXReactSchedulerDispatch.h
-@@ -1,27 +1,61 @@
+@@ -1,27 +1,68 @@
  // Copyright 2025-present 650 Industries. All rights reserved.
 +//
-+// [Better Rail] Backport of the SDK 57 fix for the use-after-free reported as
-+// Sentry BETTER-RAIL-2G. Drop this patch when upgrading to Expo SDK 57.
++// [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free. SDK 56 dereferences
++// the React `RuntimeScheduler` pointer without checking that the React instance still
++// owns it, so it crashes when an expo/fetch promise rejects after teardown (reload,
++// `RNRestart.Restart()`, termination). Sentry BETTER-RAIL-2G.
++//
++// UPGRADING: paired with `patches/expo@56.0.12.patch`, which calls
++// `createReactSchedulerHandle` below — remove both together on the Expo SDK 57 upgrade,
++// where this fix ships upstream. Keep the unrelated `DynamicConvertibleType` hunk that
++// shares this patch file (see Sentry BETTER-RAIL-2Q).
  
  #pragma once
  
@@ -96,18 +103,25 @@ index c390ad2b915474ae8cef02edcc6cecb45dd507ce..0b62004b9c2ddb1861376fbc3c39defa
  } // namespace expo
  
 diff --git a/ios/JS/EXReactSchedulerDispatch.mm b/ios/JS/EXReactSchedulerDispatch.mm
-index e9b1554e711d9c1adea32e6ed8fbc1a3e3791cd8..c059a8591bf6f00ee797b07fa304efc3ad6f28b3 100644
+index e9b1554e711d9c1adea32e6ed8fbc1a3e3791cd8..e32d1026d828f3c495e9e1b274a3c3139c29a3d0 100644
 --- a/ios/JS/EXReactSchedulerDispatch.mm
 +++ b/ios/JS/EXReactSchedulerDispatch.mm
-@@ -1,4 +1,7 @@
+@@ -1,4 +1,14 @@
  // Copyright 2025-present 650 Industries. All rights reserved.
 +//
-+// [Better Rail] Backport of the SDK 57 fix for the use-after-free reported as
-+// Sentry BETTER-RAIL-2G. Drop this patch when upgrading to Expo SDK 57.
++// [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free. SDK 56 dereferences
++// the React `RuntimeScheduler` pointer without checking that the React instance still
++// owns it, so it crashes when an expo/fetch promise rejects after teardown (reload,
++// `RNRestart.Restart()`, termination). Sentry BETTER-RAIL-2G.
++//
++// UPGRADING: paired with `patches/expo@56.0.12.patch`, which calls
++// `createReactSchedulerHandle` below — remove both together on the Expo SDK 57 upgrade,
++// where this fix ships upstream. Keep the unrelated `DynamicConvertibleType` hunk that
++// shares this patch file (see Sentry BETTER-RAIL-2Q).
  
  #import "EXReactSchedulerDispatch.h"
  
-@@ -6,9 +9,36 @@
+@@ -6,9 +16,36 @@
  
  namespace expo {
  

--- a/patches/expo-modules-core@56.0.17.patch
+++ b/patches/expo-modules-core@56.0.17.patch
@@ -22,3 +22,127 @@ index 1188204ab9d08d0f60f8b0fd9b149f97861a967b..63c4a9c7d8a9ccf6f847728696e8f9ad
      }
      return try Conversions.unknownToJavaScriptValue(value, appContext: appContext)
    }
+diff --git a/ios/JS/EXReactSchedulerDispatch.h b/ios/JS/EXReactSchedulerDispatch.h
+index c390ad2b915474ae8cef02edcc6cecb45dd507ce..0b62004b9c2ddb1861376fbc3c39defa9366b80a 100644
+--- a/ios/JS/EXReactSchedulerDispatch.h
++++ b/ios/JS/EXReactSchedulerDispatch.h
+@@ -1,27 +1,61 @@
+ // Copyright 2025-present 650 Industries. All rights reserved.
++//
++// [Better Rail] Backport of the SDK 57 fix for the use-after-free reported as
++// Sentry BETTER-RAIL-2G. Drop this patch when upgrading to Expo SDK 57.
+ 
+ #pragma once
+ 
+ #ifdef __cplusplus
+ 
++#include <memory>
++
++namespace facebook::react {
++class RuntimeScheduler;
++} // namespace facebook::react
++
+ namespace expo {
+ 
+ /**
+- Trampoline that `ExpoModulesJSI` calls to dispatch work onto the JS thread.
+- Casts the `nativeScheduler` pointer back to a `react::RuntimeScheduler *` and
+- calls `scheduleTask` on it. The signature matches `expo::RuntimeScheduler::ScheduleFn`
+- declared in the xcframework's `RuntimeScheduler.h`.
++ Creates an opaque handle for `dispatchOnReactScheduler` that references the given React
++ runtime scheduler weakly. Returns `nullptr` when the scheduler is `nullptr` (e.g. no
++ `RuntimeSchedulerBinding` was installed).
++
++ The handle is never freed by design. Dispatch calls are bounded only by the lifetime of the
++ `JavaScriptRuntime` wrapper, which any escaped closure can extend past every point at which
++ the handle could be safely deleted. Each runtime creation therefore leaks the handle and,
++ because React Native allocates the scheduler with `std::make_shared`, the weak reference
++ also keeps the scheduler's storage from being reclaimed after its destruction. That cost
++ is small and bounded, unlike the use-after-free it prevents.
++ */
++void *createReactSchedulerHandle(const std::shared_ptr<facebook::react::RuntimeScheduler> &scheduler);
++
++/**
++ Trampoline that `ExpoModulesJSI` calls to dispatch work onto the JS thread. Locks the
++ scheduler weakly referenced by the handle (created with `createReactSchedulerHandle`) and
++ calls `scheduleTask` on it. The React instance owns the scheduler and destroys it on
++ teardown (e.g. reload) while native code may still dispatch through a retained
++ `JavaScriptRuntime`, so when the scheduler is gone (or the handle is `nullptr` because
++ no scheduler existed at creation) the task is dropped instead of dereferencing freed
++ memory. The signature matches `expo::RuntimeScheduler::ScheduleFn` declared in the
++ xcframework's `RuntimeScheduler.h`.
++
++ A narrow edge remains: when the lock races the React instance's final release, this
++ thread becomes the scheduler's last owner and runs its destructor once `scheduleTask`
++ returns, off the JS thread and potentially after the runtime is gone, destroying
++ still-queued tasks that may hold JSI values. React Native's own
++ `RuntimeSchedulerCallInvoker` locks the same weak reference to schedule work, so this
++ matches upstream behavior.
+ 
+  Lives in ExpoModulesCore (rather than in the xcframework) so that
+  ExpoModulesJSI.framework's prebuilt binary doesn't need to link against
+- React-runtimescheduler — important for source-built RN, where those symbols
++ React-runtimescheduler. That matters for source-built RN, where those symbols
+  are hidden after link and unreachable via -undefined dynamic_lookup.
+ 
+  Hosts that initialize their own runtime (e.g. ExpoReactNativeFactory, Expo Go)
+  pass `&expo::dispatchOnReactScheduler` as the `dispatch` argument to
+- `AppContext.setRuntime`.
++ `AppContext.setRuntime`, with the handle as the `scheduler` argument.
+  */
+-void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept;
++void dispatchOnReactScheduler(void *schedulerHandle, int priority, void (^callback)()) noexcept;
+ 
+ } // namespace expo
+ 
+diff --git a/ios/JS/EXReactSchedulerDispatch.mm b/ios/JS/EXReactSchedulerDispatch.mm
+index e9b1554e711d9c1adea32e6ed8fbc1a3e3791cd8..c059a8591bf6f00ee797b07fa304efc3ad6f28b3 100644
+--- a/ios/JS/EXReactSchedulerDispatch.mm
++++ b/ios/JS/EXReactSchedulerDispatch.mm
+@@ -1,4 +1,7 @@
+ // Copyright 2025-present 650 Industries. All rights reserved.
++//
++// [Better Rail] Backport of the SDK 57 fix for the use-after-free reported as
++// Sentry BETTER-RAIL-2G. Drop this patch when upgrading to Expo SDK 57.
+ 
+ #import "EXReactSchedulerDispatch.h"
+ 
+@@ -6,9 +9,36 @@
+ 
+ namespace expo {
+ 
+-void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept
++namespace {
++
++struct SchedulerHandle {
++  std::weak_ptr<facebook::react::RuntimeScheduler> scheduler;
++};
++
++} // namespace
++
++void *createReactSchedulerHandle(const std::shared_ptr<facebook::react::RuntimeScheduler> &scheduler)
++{
++  if (!scheduler) {
++    return nullptr;
++  }
++  return new SchedulerHandle{scheduler};
++}
++
++void dispatchOnReactScheduler(void *schedulerHandle, int priority, void (^callback)()) noexcept
+ {
+-  auto *scheduler = static_cast<facebook::react::RuntimeScheduler *>(nativeScheduler);
++  auto *handle = static_cast<SchedulerHandle *>(schedulerHandle);
++  if (handle == nullptr) {
++    // `createReactSchedulerHandle` returns null when there was no scheduler to reference.
++    // Drop the task so callers don't have to guard the handle/dispatch pair themselves.
++    return;
++  }
++  // Locking either keeps the scheduler alive for the duration of `scheduleTask` or reports
++  // that the React instance already destroyed it, in which case the task is dropped.
++  auto scheduler = handle->scheduler.lock();
++  if (!scheduler) {
++    return;
++  }
+   scheduler->scheduleTask(
+     static_cast<facebook::react::SchedulerPriority>(priority),
+     [callback](facebook::jsi::Runtime &) {

--- a/patches/expo-modules-core@56.0.17.patch
+++ b/patches/expo-modules-core@56.0.17.patch
@@ -23,21 +23,18 @@ index 1188204ab9d08d0f60f8b0fd9b149f97861a967b..63c4a9c7d8a9ccf6f847728696e8f9ad
      return try Conversions.unknownToJavaScriptValue(value, appContext: appContext)
    }
 diff --git a/ios/JS/EXReactSchedulerDispatch.h b/ios/JS/EXReactSchedulerDispatch.h
-index c390ad2b915474ae8cef02edcc6cecb45dd507ce..3a35683e4481c647f807e3e9fe098c718dace0e5 100644
+index c390ad2b915474ae8cef02edcc6cecb45dd507ce..073a2200b6e3b1db4a136c581b54a591b7c830e1 100644
 --- a/ios/JS/EXReactSchedulerDispatch.h
 +++ b/ios/JS/EXReactSchedulerDispatch.h
-@@ -1,27 +1,68 @@
+@@ -1,27 +1,65 @@
  // Copyright 2025-present 650 Industries. All rights reserved.
 +//
-+// [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free. SDK 56 dereferences
-+// the React `RuntimeScheduler` pointer without checking that the React instance still
-+// owns it, so it crashes when an expo/fetch promise rejects after teardown (reload,
-+// `RNRestart.Restart()`, termination). Sentry BETTER-RAIL-2G.
++// [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free: SDK 56 dereferences
++// the React `RuntimeScheduler` pointer without checking the React instance still owns
++// it, crashing when an expo/fetch promise rejects after teardown. BETTER-RAIL-2G.
 +//
-+// UPGRADING: paired with `patches/expo@56.0.12.patch`, which calls
-+// `createReactSchedulerHandle` below — remove both together on the Expo SDK 57 upgrade,
-+// where this fix ships upstream. Keep the unrelated `DynamicConvertibleType` hunk that
-+// shares this patch file (see Sentry BETTER-RAIL-2Q).
++// UPGRADING: paired with `patches/expo@56.0.12.patch`. Delete both on SDK 57, but keep
++// the unrelated `DynamicConvertibleType` hunk sharing this patch file.
  
  #pragma once
  
@@ -103,25 +100,22 @@ index c390ad2b915474ae8cef02edcc6cecb45dd507ce..3a35683e4481c647f807e3e9fe098c71
  } // namespace expo
  
 diff --git a/ios/JS/EXReactSchedulerDispatch.mm b/ios/JS/EXReactSchedulerDispatch.mm
-index e9b1554e711d9c1adea32e6ed8fbc1a3e3791cd8..e32d1026d828f3c495e9e1b274a3c3139c29a3d0 100644
+index e9b1554e711d9c1adea32e6ed8fbc1a3e3791cd8..85561ceaf485d57478d63c5a5839e5ee904387b7 100644
 --- a/ios/JS/EXReactSchedulerDispatch.mm
 +++ b/ios/JS/EXReactSchedulerDispatch.mm
-@@ -1,4 +1,14 @@
+@@ -1,4 +1,11 @@
  // Copyright 2025-present 650 Industries. All rights reserved.
 +//
-+// [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free. SDK 56 dereferences
-+// the React `RuntimeScheduler` pointer without checking that the React instance still
-+// owns it, so it crashes when an expo/fetch promise rejects after teardown (reload,
-+// `RNRestart.Restart()`, termination). Sentry BETTER-RAIL-2G.
++// [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free: SDK 56 dereferences
++// the React `RuntimeScheduler` pointer without checking the React instance still owns
++// it, crashing when an expo/fetch promise rejects after teardown. BETTER-RAIL-2G.
 +//
-+// UPGRADING: paired with `patches/expo@56.0.12.patch`, which calls
-+// `createReactSchedulerHandle` below — remove both together on the Expo SDK 57 upgrade,
-+// where this fix ships upstream. Keep the unrelated `DynamicConvertibleType` hunk that
-+// shares this patch file (see Sentry BETTER-RAIL-2Q).
++// UPGRADING: paired with `patches/expo@56.0.12.patch`. Delete both on SDK 57, but keep
++// the unrelated `DynamicConvertibleType` hunk sharing this patch file.
  
  #import "EXReactSchedulerDispatch.h"
  
-@@ -6,9 +16,36 @@
+@@ -6,9 +13,36 @@
  
  namespace expo {
  

--- a/patches/expo@56.0.12.patch
+++ b/patches/expo@56.0.12.patch
@@ -1,69 +1,38 @@
 diff --git a/ios/AppDelegates/ExpoReactNativeFactory.mm b/ios/AppDelegates/ExpoReactNativeFactory.mm
-index 8dec877617b0a971a44a1eeb9d7674ab981c945c..732ecef48a43158cb573c32cfb1ec8760ac3b624 100644
+index 8dec877617b0a971a44a1eeb9d7674ab981c945c..49b7e392c0a5ef9ae91e7d95c3bdf2f7f9dd75ad 100644
 --- a/ios/AppDelegates/ExpoReactNativeFactory.mm
 +++ b/ios/AppDelegates/ExpoReactNativeFactory.mm
-@@ -22,6 +22,50 @@
- #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
- #import <ExpoModulesCore/EXReactSchedulerDispatch.h>
+@@ -43,20 +43,28 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
  
-+#include <memory>
-+#include <mutex>
-+#include <vector>
-+
-+namespace {
-+
-+/**
-+ The React `RuntimeScheduler` is owned by the `ReactInstance`, but `setRuntime:`
-+ below only hands over a raw pointer to it — `expo::RuntimeScheduler` (in the
-+ prebuilt ExpoModulesJSI) stores it as a bare `void *` and never takes ownership.
-+ Native work that settles *after* the React instance is torn down still dispatches
-+ through that pointer, so it reads freed memory and crashes inside
-+ `facebook::react::RuntimeScheduler::scheduleTask`.
-+
-+ That is not hypothetical: tearing the instance down (e.g. `RNRestart.Restart()`
-+ from the initial-language setup) runs `ExpoFetchModule`'s `OnDestroy`, which calls
-+ `urlSession.invalidateAndCancel()`. The cancelled requests then reject their JS
-+ promises from `expo.modules.fetch.RequestQueue`, hitting the dangling scheduler.
-+ See Sentry BETTER-RAIL-2G.
-+
-+ Keep a strong reference to every scheduler we expose so the pointer stays valid
-+ for the lifetime of the process. Scheduling on an orphaned scheduler is a no-op
-+ rather than a crash: `RuntimeScheduler` dispatches through the `RuntimeExecutor`
-+ that `ReactInstance` built, and that executor bails out as soon as its weak
-+ reference to the runtime has expired.
-+
-+ Upstream still passes the unowned pointer as of expo@56.0.21 — re-check when
-+ bumping the SDK.
-+ */
-+void retainRuntimeSchedulerForProcessLifetime(std::shared_ptr<facebook::react::RuntimeScheduler> scheduler)
-+{
-+  // Intentionally leaked: these must outlive static destruction too, since
-+  // background queues can still dispatch through them while the process exits.
-+  // `RuntimeScheduler` stays incomplete here — we only move and store the
-+  // `shared_ptr`, exactly like the unpatched code already does.
-+  static auto *retained = new std::vector<std::shared_ptr<facebook::react::RuntimeScheduler>>();
-+  static auto *mutex = new std::mutex();
-+
-+  std::lock_guard<std::mutex> lock(*mutex);
-+  retained->push_back(std::move(scheduler));
-+}
-+
-+} // namespace
-+
- @implementation EXReactNativeFactory {
-   EXAppContext *_appContext;
- }
-@@ -54,6 +98,13 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
+   // Resolve the React runtime scheduler so ExpoModulesJSI can dispatch work onto
+   // the JS thread. Doing it here (rather than inside the xcframework) keeps
+-  // React-runtimescheduler symbols out of the prebuilt ExpoModulesJSI.framework
+-  // — important for source-built RN, where those symbols are hidden after link
++  // React-runtimescheduler symbols out of the prebuilt ExpoModulesJSI.framework.
++  // That matters for source-built RN, where those symbols are hidden after link
+   // and unreachable via -undefined dynamic_lookup.
+   //
++  // The handle references the scheduler weakly, so dispatching after the React
++  // instance tore it down (e.g. on reload) drops the task instead of calling
++  // into freed memory. See `EXReactSchedulerDispatch.h`.
++  //
+   // If RN didn't install a RuntimeSchedulerBinding for some reason, pass nullptr
+-  // for both — AppContext.setRuntime falls back to a synchronous no-op scheduler
++  // for both. AppContext.setRuntime falls back to a synchronous no-op scheduler
+   // so the app still launches; modules that require async dispatch can gate on
+   // `JavaScriptRuntime.supportsAsyncScheduling`.
++  //
++  // [Better Rail] Backport of the SDK 57 fix for the use-after-free reported as
++  // Sentry BETTER-RAIL-2G. Drop this patch when upgrading to Expo SDK 57.
    auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
    auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
++  void *schedulerHandle = expo::createReactSchedulerHandle(scheduler);
  
-+  // `setRuntime:` keeps only the raw pointer, so make sure the scheduler outlives
-+  // the React instance it belongs to. See the note above
-+  // `retainRuntimeSchedulerForProcessLifetime`.
-+  if (scheduler) {
-+    retainRuntimeSchedulerForProcessLifetime(scheduler);
-+  }
-+
    [_appContext setRuntime:&runtime
-                 scheduler:scheduler.get()
-                  dispatch:scheduler ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
+-                scheduler:scheduler.get()
+-                 dispatch:scheduler ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
++                scheduler:schedulerHandle
++                 dispatch:schedulerHandle ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
+   [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
+ 
+   [_appContext registerNativeModules];

--- a/patches/expo@56.0.12.patch
+++ b/patches/expo@56.0.12.patch
@@ -1,8 +1,8 @@
 diff --git a/ios/AppDelegates/ExpoReactNativeFactory.mm b/ios/AppDelegates/ExpoReactNativeFactory.mm
-index 8dec877617b0a971a44a1eeb9d7674ab981c945c..d2a37e9307a44f180b2ff6c746b91f0ef757cf7a 100644
+index 8dec877617b0a971a44a1eeb9d7674ab981c945c..dae7dbe24b91c132fecdadf13b4126309132044b 100644
 --- a/ios/AppDelegates/ExpoReactNativeFactory.mm
 +++ b/ios/AppDelegates/ExpoReactNativeFactory.mm
-@@ -43,20 +43,38 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
+@@ -43,20 +43,33 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
  
    // Resolve the React runtime scheduler so ExpoModulesJSI can dispatch work onto
    // the JS thread. Doing it here (rather than inside the xcframework) keeps
@@ -22,18 +22,13 @@ index 8dec877617b0a971a44a1eeb9d7674ab981c945c..d2a37e9307a44f180b2ff6c746b91f0e
    // so the app still launches; modules that require async dispatch can gate on
    // `JavaScriptRuntime.supportsAsyncScheduling`.
 +  //
-+  // [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free. SDK 56 passes
-+  // `scheduler.get()` straight through and `expo::RuntimeScheduler` keeps it as a bare
-+  // `void *`, so the pointer dangles as soon as the React instance is torn down — by
-+  // `RNRestart.Restart()`, a reload, or termination. Any expo/fetch request still in
-+  // flight is then cancelled by `ExpoFetchModule`'s `OnDestroy` and rejects its promise
-+  // through the freed scheduler. Sentry BETTER-RAIL-2G.
++  // [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free: SDK 56 passes
++  // `scheduler.get()` as a bare pointer, which dangles once the React instance is torn
++  // down and an expo/fetch promise rejects through it. Sentry BETTER-RAIL-2G.
 +  //
-+  // UPGRADING: `expo::createReactSchedulerHandle` is added by the matching hunk in
-+  // `patches/expo-modules-core@56.0.17.patch` — the two patches are a pair, and removing
-+  // only one breaks the build. Delete both on the Expo SDK 57 upgrade, where this fix
-+  // ships upstream. There is no 56.x to upgrade to instead: `expo@56.0.21` and
-+  // `expo-modules-core@56.0.25` are the newest 56.x releases and still carry the bug.
++  // UPGRADING: needs the EXReactSchedulerDispatch hunks in
++  // `patches/expo-modules-core@56.0.17.patch` — won't compile without them. Delete both
++  // patches on SDK 57; no 56.x release carries the fix.
    auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
    auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
 +  void *schedulerHandle = expo::createReactSchedulerHandle(scheduler);

--- a/patches/expo@56.0.12.patch
+++ b/patches/expo@56.0.12.patch
@@ -1,0 +1,69 @@
+diff --git a/ios/AppDelegates/ExpoReactNativeFactory.mm b/ios/AppDelegates/ExpoReactNativeFactory.mm
+index 8dec877617b0a971a44a1eeb9d7674ab981c945c..732ecef48a43158cb573c32cfb1ec8760ac3b624 100644
+--- a/ios/AppDelegates/ExpoReactNativeFactory.mm
++++ b/ios/AppDelegates/ExpoReactNativeFactory.mm
+@@ -22,6 +22,50 @@
+ #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+ #import <ExpoModulesCore/EXReactSchedulerDispatch.h>
+ 
++#include <memory>
++#include <mutex>
++#include <vector>
++
++namespace {
++
++/**
++ The React `RuntimeScheduler` is owned by the `ReactInstance`, but `setRuntime:`
++ below only hands over a raw pointer to it — `expo::RuntimeScheduler` (in the
++ prebuilt ExpoModulesJSI) stores it as a bare `void *` and never takes ownership.
++ Native work that settles *after* the React instance is torn down still dispatches
++ through that pointer, so it reads freed memory and crashes inside
++ `facebook::react::RuntimeScheduler::scheduleTask`.
++
++ That is not hypothetical: tearing the instance down (e.g. `RNRestart.Restart()`
++ from the initial-language setup) runs `ExpoFetchModule`'s `OnDestroy`, which calls
++ `urlSession.invalidateAndCancel()`. The cancelled requests then reject their JS
++ promises from `expo.modules.fetch.RequestQueue`, hitting the dangling scheduler.
++ See Sentry BETTER-RAIL-2G.
++
++ Keep a strong reference to every scheduler we expose so the pointer stays valid
++ for the lifetime of the process. Scheduling on an orphaned scheduler is a no-op
++ rather than a crash: `RuntimeScheduler` dispatches through the `RuntimeExecutor`
++ that `ReactInstance` built, and that executor bails out as soon as its weak
++ reference to the runtime has expired.
++
++ Upstream still passes the unowned pointer as of expo@56.0.21 — re-check when
++ bumping the SDK.
++ */
++void retainRuntimeSchedulerForProcessLifetime(std::shared_ptr<facebook::react::RuntimeScheduler> scheduler)
++{
++  // Intentionally leaked: these must outlive static destruction too, since
++  // background queues can still dispatch through them while the process exits.
++  // `RuntimeScheduler` stays incomplete here — we only move and store the
++  // `shared_ptr`, exactly like the unpatched code already does.
++  static auto *retained = new std::vector<std::shared_ptr<facebook::react::RuntimeScheduler>>();
++  static auto *mutex = new std::mutex();
++
++  std::lock_guard<std::mutex> lock(*mutex);
++  retained->push_back(std::move(scheduler));
++}
++
++} // namespace
++
+ @implementation EXReactNativeFactory {
+   EXAppContext *_appContext;
+ }
+@@ -54,6 +98,13 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
+   auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
+   auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
+ 
++  // `setRuntime:` keeps only the raw pointer, so make sure the scheduler outlives
++  // the React instance it belongs to. See the note above
++  // `retainRuntimeSchedulerForProcessLifetime`.
++  if (scheduler) {
++    retainRuntimeSchedulerForProcessLifetime(scheduler);
++  }
++
+   [_appContext setRuntime:&runtime
+                 scheduler:scheduler.get()
+                  dispatch:scheduler ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];

--- a/patches/expo@56.0.12.patch
+++ b/patches/expo@56.0.12.patch
@@ -1,8 +1,8 @@
 diff --git a/ios/AppDelegates/ExpoReactNativeFactory.mm b/ios/AppDelegates/ExpoReactNativeFactory.mm
-index 8dec877617b0a971a44a1eeb9d7674ab981c945c..49b7e392c0a5ef9ae91e7d95c3bdf2f7f9dd75ad 100644
+index 8dec877617b0a971a44a1eeb9d7674ab981c945c..d2a37e9307a44f180b2ff6c746b91f0ef757cf7a 100644
 --- a/ios/AppDelegates/ExpoReactNativeFactory.mm
 +++ b/ios/AppDelegates/ExpoReactNativeFactory.mm
-@@ -43,20 +43,28 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
+@@ -43,20 +43,38 @@ - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtim
  
    // Resolve the React runtime scheduler so ExpoModulesJSI can dispatch work onto
    // the JS thread. Doing it here (rather than inside the xcframework) keeps
@@ -22,8 +22,18 @@ index 8dec877617b0a971a44a1eeb9d7674ab981c945c..49b7e392c0a5ef9ae91e7d95c3bdf2f7
    // so the app still launches; modules that require async dispatch can gate on
    // `JavaScriptRuntime.supportsAsyncScheduling`.
 +  //
-+  // [Better Rail] Backport of the SDK 57 fix for the use-after-free reported as
-+  // Sentry BETTER-RAIL-2G. Drop this patch when upgrading to Expo SDK 57.
++  // [Better Rail] Backport of Expo's SDK 57 fix for a use-after-free. SDK 56 passes
++  // `scheduler.get()` straight through and `expo::RuntimeScheduler` keeps it as a bare
++  // `void *`, so the pointer dangles as soon as the React instance is torn down — by
++  // `RNRestart.Restart()`, a reload, or termination. Any expo/fetch request still in
++  // flight is then cancelled by `ExpoFetchModule`'s `OnDestroy` and rejects its promise
++  // through the freed scheduler. Sentry BETTER-RAIL-2G.
++  //
++  // UPGRADING: `expo::createReactSchedulerHandle` is added by the matching hunk in
++  // `patches/expo-modules-core@56.0.17.patch` — the two patches are a pair, and removing
++  // only one breaks the build. Delete both on the Expo SDK 57 upgrade, where this fix
++  // ships upstream. There is no 56.x to upgrade to instead: `expo@56.0.21` and
++  // `expo-modules-core@56.0.25` are the newest 56.x releases and still carry the bug.
    auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
    auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
 +  void *schedulerHandle = expo::createReactSchedulerHandle(scheduler);

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -88,12 +88,9 @@ export function setUserLanguage(languageCode: LanguageCode, allowRestart = false
   }
 
   if (allowRestart) {
-    // Restarting tears down the React instance, which cancels every in-flight expo/fetch
-    // request. On iOS those cancellations used to reject through a freed RuntimeScheduler
-    // and crash (Sentry BETTER-RAIL-2G) — keep patches/expo@*.patch and the
-    // EXReactSchedulerDispatch hunks of patches/expo-modules-core@*.patch for as long as
-    // we restart the app from JS (here and in settings-privacy-screen). The fault is in
-    // Expo's scheduler handling, not in RNRestart — upgrading that library doesn't help.
+    // Tearing down the React instance cancels in-flight expo/fetch requests, which used
+    // to crash in Expo's RuntimeScheduler (BETTER-RAIL-2G). Keep the expo and
+    // expo-modules-core patches while we restart from JS; the fault isn't in RNRestart.
     //
     // On Android, SharedPreferences.apply() is asynchronous. Without a delay,
     // Runtime.exit(0) in RNRestart can race with the async write and lose the

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -88,6 +88,13 @@ export function setUserLanguage(languageCode: LanguageCode, allowRestart = false
   }
 
   if (allowRestart) {
+    // Restarting tears down the React instance, which cancels every in-flight expo/fetch
+    // request. On iOS those cancellations used to reject through a freed RuntimeScheduler
+    // and crash (Sentry BETTER-RAIL-2G) — keep patches/expo@*.patch and the
+    // EXReactSchedulerDispatch hunks of patches/expo-modules-core@*.patch for as long as
+    // we restart the app from JS (here and in settings-privacy-screen). The fault is in
+    // Expo's scheduler handling, not in RNRestart — upgrading that library doesn't help.
+    //
     // On Android, SharedPreferences.apply() is asynchronous. Without a delay,
     // Runtime.exit(0) in RNRestart can race with the async write and lose the
     // forceRTL preference, causing the UI direction to stay stale after restart.


### PR DESCRIPTION
Fixes [BETTER-RAIL-2G](https://better-rail.sentry.io/issues/7580540422/): a crash on first launch, iOS only. 773 events across 774 users, so roughly once per new user.

## What happens

On a fresh install there's no saved language yet, so the app picks one and calls `RNRestart.Restart()` a moment into the launch. That restart tears down the React instance.

Expo SDK 56 has a bug here: it hands its native layer a raw pointer to React's `RuntimeScheduler` without keeping it alive, so the pointer goes stale the moment the instance is torn down.

The same restart also cancels every in-flight network request — `expo/fetch` is the global `fetch` in SDK 56, so that's all of them. Those cancelled requests then try to reject their promises through the stale pointer, and the app crashes.

## The fix

Expo fixed this in SDK 57 but never backported it to the 56 line, so this PR backports their fix as patches:

- `expo-modules-core` — holds the scheduler weakly and drops the work if React already tore it down
- `expo` — passes that weak handle instead of the raw pointer

The two patches are a pair and should be deleted together when we move to SDK 57. 