### PR TITLE
fix(ios): reset tip jar loading state after purchase request settles

### DIFF
--- a/src/screens/settings/settings-tip-jar-screen.tsx
+++ b/src/screens/settings/settings-tip-jar-screen.tsx
@@ -26,9 +26,9 @@ export function TipJarScreen() {
 
   const handlePurchaseSuccess = async (purchase: Purchase) => {
     try {
-      await finishTransaction({ purchase, isConsumable: true })
-
       setShowThanksModal(true)
+
+      await finishTransaction({ purchase, isConsumable: true })
 
       const item = products.find((product) => product.id === purchase.productId)
       if (item?.price != null) {

--- a/src/screens/settings/settings-tip-jar-screen.tsx
+++ b/src/screens/settings/settings-tip-jar-screen.tsx
@@ -96,6 +96,7 @@ export function TipJarScreen() {
     } catch (err) {
       console.error("[TipJar] Error requesting purchase:", err)
       Sentry.captureException(err)
+    } finally {
       setIsLoading(false)
     }
   }


### PR DESCRIPTION
Move `setIsLoading(false)` into a `finally` block so the tip buttons always come back once `requestPurchase` settles.
Previously the spinner could get stuck when neither the success nor the error callback fired.