### PR TITLE
feat: add new station search aliases 

### DIFF
--- a/src/data/stations.test.ts
+++ b/src/data/stations.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import Fuse from "fuse.js"
+import { setStationLocale, useStations } from "./stations"
+
+const appendedStationNames = [
+  { id: "1280", canonicalName: "בית שאן", keywords: ["דוד לוי", "David Levy", "Давид Леви", "دڤيد لِڤي"] },
+  {
+    id: "3600",
+    canonicalName: "תל אביב - אוניברסיטה",
+    keywords: ["אקספו", "Expo", "Экспо", "إكسپو"],
+  },
+  {
+    id: "4680",
+    canonicalName: "בת ים - יוספטל",
+    keywords: ["אלי כהן", "Eli Cohen", "Эли Коэн", "إلي كوهين"],
+  },
+  {
+    id: "5800",
+    canonicalName: "אשדוד עד הלום",
+    keywords: ["מטרופול", "Metropol", "Метропол", "متروپول"],
+  },
+]
+
+describe("station aliases", () => {
+  test("keeps appended co-names out of the displayed station names", () => {
+    setStationLocale("he")
+
+    const stationsById = new Map(useStations().map((station) => [station.id, station]))
+
+    for (const { id, canonicalName, keywords } of appendedStationNames) {
+      const station = stationsById.get(id)
+
+      expect(station?.name).toBe(canonicalName)
+      expect(station?.alias).toEqual(keywords)
+    }
+  })
+
+  test("finds each station by every localized co-name", () => {
+    setStationLocale("he")
+
+    const stations = useStations()
+    const stationSearch = new Fuse(stations, { keys: ["name", "hebrew", "alias"], threshold: 0.3 })
+
+    for (const { id, keywords } of appendedStationNames) {
+      for (const keyword of keywords) {
+        expect(stationSearch.search(keyword)[0]?.item.id).toBe(id)
+      }
+    }
+  })
+})

--- a/src/data/stations.ts
+++ b/src/data/stations.ts
@@ -320,6 +320,7 @@ const stations: Station[] = [
     lat: 31.774061,
     lon: 34.666059,
     image: require("../../assets/station-images/ashdod.jpg"),
+    alias: ["מטרופול", "Metropol", "Метропол", "متروپول"],
   },
   {
     id: "4250",
@@ -350,6 +351,7 @@ const stations: Station[] = [
     lat: 32.103516,
     lon: 34.804499,
     image: require("../../assets/station-images/tlv-university.jpg"),
+    alias: ["אקספו", "Expo", "Экспо", "إكسپو"],
   },
   {
     id: "7320",
@@ -509,6 +511,7 @@ const stations: Station[] = [
     lat: 32.014588,
     lon: 34.762082,
     image: require("../../assets/station-images/bat-yam-yoseftal.jpg"),
+    alias: ["אלי כהן", "Eli Cohen", "Эли Коэн", "إلي كوهين"],
   },
   {
     id: "4690",
@@ -619,6 +622,7 @@ const stations: Station[] = [
     lat: 32.514683,
     lon: 35.488106,
     image: require("../../assets/station-images/beit-shean.jpg"),
+    alias: ["דוד לוי", "David Levy", "Давид Леви", "دڤيد لِڤي"],
   },
   {
     id: "1820",
@@ -755,14 +759,12 @@ function normalizeStation(station: Station): NormalizedStation {
     name: station[stationLocale],
     image: station.image,
     hebrew: station.hebrew,
-    alias: station.alias,
+    alias: station.alias ?? [],
   }
 }
 
 export const useStations = (): NormalizedStation[] =>
-  stations
-    .map(normalizeStation)
-    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+  stations.map(normalizeStation).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
 
 /**
  * Resolves a single station by id using `stationLocale` at call time.


### PR DESCRIPTION
Add new station co-names as searchable aliases.
Keep canonical station names unchanged.