### PR TITLE
fix(widget): show 'no more trains' instead of error on last train in large widget

### DIFF
--- a/targets/widget/Views/WidgetLargeScheduleView.swift
+++ b/targets/widget/Views/WidgetLargeScheduleView.swift
@@ -10,7 +10,7 @@ struct WidgetLargeScheduleView: View {
           VStack {
             Spacer()
             Image(systemName: "tram").padding(.vertical, 1).font(.system(size: 24))
-            Text(statusCode == "300" ? "No more trains for today." : "Something went wrong.")
+            Text(statusCode == "404" ? "Something went wrong." : "No more trains for today.")
             Spacer()
           }.padding(.bottom, 16)
           


### PR DESCRIPTION
The large widget's empty schedule treated any non-300 status as an error, so the last train of the day showed "Something went wrong."