### PR TITLE
chore: remove unused _editorconfig template leftover

### DIFF
--- a/_editorconfig
+++ b/_editorconfig
@@ -1,3 +1,0 @@
-# Windows files
-[*.bat]
-end_of_line = crlf


### PR DESCRIPTION
Removes `_editorconfig`, a React Native template artifact that was never renamed to `.editorconfig`, so no editor reads it. Its only rule targets `*.bat` files, of which the repo has none.