### PR TITLE
Spell Akko correctly in the English station name

### DIFF
--- a/apps/mobile/src/data/stations.ts
+++ b/apps/mobile/src/data/stations.ts
@@ -145,7 +145,7 @@ const stations: Station[] = [
   {
     id: "1500",
     hebrew: "עכו",
-    english: "Ako",
+    english: "Akko",
     russian: "Акко ",
     arabic: "عكا",
     lat: 32.928339,


### PR DESCRIPTION
Closes #737

The English name for station 1500 was Ako. It should be Akko, which matches the Hebrew name.

This updates the english field in apps/mobile/src/data/stations.ts. Asset filenames were left alone.