### PR TITLE
feat(mobile): bring back train info button

### DIFF
--- a/apps/mobile/src/i18n/ar.json
+++ b/apps/mobile/src/i18n/ar.json
@@ -112,6 +112,7 @@
     "carsCount": "%{count} عربات",
     "seatsCount": "%{count} مقاعد",
     "trainInformation": "معلومات القطار",
+    "noTrainDetails": "تفاصيل القطار غير متوفرة بعد لهذا القطار.",
     "noWagonInformationAvailable": "لا توجد معلومات عن العربات متاحة"
   },
   "settings": {

--- a/apps/mobile/src/i18n/en.json
+++ b/apps/mobile/src/i18n/en.json
@@ -119,6 +119,7 @@
     "carsCount": "%{count} cars",
     "seatsCount": "%{count} seats",
     "trainInformation": "Train information",
+    "noTrainDetails": "Train details are not available yet for this train.",
     "noWagonInformationAvailable": "No wagon information available"
   },
   "settings": {

--- a/apps/mobile/src/i18n/he.json
+++ b/apps/mobile/src/i18n/he.json
@@ -119,6 +119,7 @@
     "carsCount": "%{count} קרונות",
     "seatsCount": "%{count} מושבים",
     "trainInformation": "פרטי רכבת",
+    "noTrainDetails": "פרטי הרכבת עדיין לא זמינים לנסיעה זו.",
     "noWagonInformationAvailable": "לא נמצא מידע על הרכבת"
   },
   "settings": {

--- a/apps/mobile/src/i18n/ru.json
+++ b/apps/mobile/src/i18n/ru.json
@@ -116,6 +116,7 @@
     "carsCount": "%{count} вагонов",
     "seatsCount": "%{count} мест",
     "trainInformation": "Информация о поезде",
+    "noTrainDetails": "Подробности о поезде пока недоступны.",
     "noWagonInformationAvailable": "Информация о вагонах недоступна"
   },
   "settings": {

--- a/apps/mobile/src/screens/route-details/route-details-screen.tsx
+++ b/apps/mobile/src/screens/route-details/route-details-screen.tsx
@@ -356,7 +356,7 @@ export function RouteDetailsScreen() {
                 }
               }}
               accessibilityLabel={translate("routeDetails.trainInformation") ?? undefined}
-              accessibilityState={{ disabled: !hasWagonData }}
+              accessibilityHint={!hasWagonData ? (translate("routeDetails.noTrainDetails") ?? undefined) : undefined}
             >
               <LiquidGlassView
                 style={[styles.infoButton, !hasWagonData && styles.infoButtonDisabled]}

--- a/apps/mobile/src/screens/route-details/route-details-screen.tsx
+++ b/apps/mobile/src/screens/route-details/route-details-screen.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { useEffect, useMemo, useState } from "react"
-import { Image, Platform, PlatformColor, Pressable, View } from "react-native"
+import { Alert, Image, Platform, PlatformColor, Pressable, View } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
 import { ScrollView } from "react-native-gesture-handler"
 import Animated, { FadeInDown, FadeOutDown } from "react-native-reanimated"
@@ -344,26 +344,29 @@ export function RouteDetailsScreen() {
               gap: spacing[3],
             }}
           >
-            {hasWagonData && (
-              <Pressable
-                onPress={() => {
+            <Pressable
+              onPress={() => {
+                if (hasWagonData) {
                   trackEvent("train_info_sheet_opened")
                   HapticFeedback.trigger("impactLight")
                   useNavigationParamsStore.getState().setTrainInfo(routeItem.trains[0])
                   router.push("/train-info")
-                }}
-                accessibilityLabel={translate("routeDetails.trainInformation")}
+                } else {
+                  Alert.alert(translate("routeDetails.trainInformation") ?? "", translate("routeDetails.noTrainDetails") ?? "")
+                }
+              }}
+              accessibilityLabel={translate("routeDetails.trainInformation") ?? undefined}
+              accessibilityState={{ disabled: !hasWagonData }}
+            >
+              <LiquidGlassView
+                style={[styles.infoButton, !hasWagonData && styles.infoButtonDisabled]}
+                interactive={hasWagonData}
+                effect="regular"
+                tintColor={PlatformColor("tertiarySystemBackground")}
               >
-                <LiquidGlassView
-                  style={styles.infoButton}
-                  interactive
-                  effect="regular"
-                  tintColor={PlatformColor("tertiarySystemBackground")}
-                >
-                  <Image source={require("../../../assets/info.circle.png")} style={styles.infoButtonIcon} />
-                </LiquidGlassView>
-              </Pressable>
-            )}
+                <Image source={require("../../../assets/info.circle.png")} style={styles.infoButtonIcon} />
+              </LiquidGlassView>
+            </Pressable>
 
             <StartRideButton route={routeItem} screenName={screenName} />
           </Animated.View>
@@ -373,7 +376,7 @@ export function RouteDetailsScreen() {
   )
 }
 
-const styles = StyleSheet.create((theme) => ({
+const styles = StyleSheet.create((theme, rt) => ({
   root: {
     flex: 1,
     backgroundColor: theme.colors.background,
@@ -386,10 +389,19 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.background,
   },
   infoButton: {
-    padding: Platform.select({ ios: 14, android: 18 }),
+    // The text button renders 4pt taller than its minimum at the default font
+    // scale because of its line box and padding. Match that visible surface.
+    width: Math.max(59, 55 * Math.min(rt.fontScale, 1.2)),
+    height: Math.max(59, 55 * Math.min(rt.fontScale, 1.2)),
+    alignItems: "center",
+    justifyContent: "center",
     borderRadius: Platform.select({ ios: 16, android: 6 }),
+    borderCurve: "continuous",
     backgroundColor: isLiquidGlassSupported ? undefined : theme.colors.tertiaryBackground,
     elevation: 1,
+  },
+  infoButtonDisabled: {
+    opacity: 0.5,
   },
   infoButtonIcon: {
     width: 24,


### PR DESCRIPTION
The train info button was hidden entirely when no wagon data was available. Now it always renders (dimmed) and shows an alert explaining details aren't available yet.

Also fixed the button sizing so it matches the height of the adjacent start-ride button.