### PR TITLE
feat(mobile): enable Sentry tombstone reporting on Android

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -47,6 +47,7 @@ const TELEMETRY_DISABLED_STORAGE_KEY = "telemetry_disabled"
 Sentry.init({
   dsn: "https://203d8d08bca79bc415c95f41ab496d0b@o4510306230534144.ingest.us.sentry.io/4510307294248960",
   enabled: !__DEV__,
+  enableTombstone: true,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   integrations: [


### PR DESCRIPTION
Enables `enableTombstone` in `Sentry.init` so native crashes on Android 12+ are reported via ApplicationExitInfo tombstones with thread details.