### PR TITLE
feat(server): gate ride tracking behind a flag

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -14,6 +14,9 @@ SIRI_CA_PEM=
 SIRI_TLS_INSECURE=
 SIRI_DEBUG_TOKEN=
 SIRI_POLLER_MODE=
+# Ride tracking (redis rides + push to real users). Auto-on for the Railway
+# deployment, off locally — set to true only when you mean to test rides.
+RIDES_ENABLED=
 # gtfs (default) = MOT feed + SIRI; rail = proxy the Israel Railways API
 RAIL_DATA_SOURCE=
 RAIL_URL=

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -130,6 +130,24 @@ active feed atomically, so the live API never reads a half-loaded feed. It abort
 (keeping the previous feed) if a station that trips actually traverse has no
 mapping.
 
+### Ride tracking
+
+Rides are **shared state**: the `rides:*` hashes in redis and the push tokens of
+real passengers. A process that boots with tracking on runs
+`scheduleExistingRides()`, which picks up *every* active ride in redis, schedules
+a second set of notifications for each and deletes the ones it can't reschedule —
+so a local run pointed at the production redis would push duplicates to real
+passengers and end their Live Activities.
+
+Tracking is therefore **opt-in**: `RIDES_ENABLED` decides, and when it's unset the
+fallback is whether `RAILWAY_ENVIRONMENT_NAME`/`_ID` are present — Railway injects
+those into every runtime container, and nothing sets them on a laptop. With it off the
+boot reschedule is skipped — logged as a warning — and `/api/v1/ride/*` answers
+`503 {"success": false, "reason": "rides_disabled"}`, so the process never reads
+or writes ride state at all. Set `RIDES_ENABLED=true` explicitly on the deployed
+service rather than relying on the Railway variable, and locally only while
+testing rides against your own device.
+
 ### Real-time data: SIRI-SM
 
 Live delays (`trainPosition.calcDiffMinutes`) and platform changes come from the
@@ -177,5 +195,6 @@ test-fixture source) and `GET /api/v1/siri/unmatched` (correlation misses).
 - `SIRI_CA_PEM`: PEM chain (intermediate + root, `\n`-escaped) to trust for SIRI requests — moran.mot.gov.il serves an incomplete chain
 - `SIRI_TLS_INSECURE`: `true` skips TLS verification for SIRI requests only (fallback until `SIRI_CA_PEM` is captured)
 - `SIRI_DEBUG_TOKEN`: secret for the `/api/v1/siri/*` debug routes; unset = routes 404
+- `RIDES_ENABLED`: `true`/`false` — whether this process tracks rides; see [Ride tracking](#ride-tracking)
 - `SIRI_POLLER_MODE`: set to `in-process` to run the poller inside the web service instead of the standalone `bun run siri` service
 - `SIRI_POLL_SECONDS` / `SIRI_PREVIEW_INTERVAL` / `SIRI_CHUNK_SIZE` / `SIRI_STALE_SECONDS` / `SIRI_CARRY_SECONDS`: optional tuning (defaults 30 / PT90M / 70 / 600 / 86400)

--- a/apps/server/src/data/config.ts
+++ b/apps/server/src/data/config.ts
@@ -16,6 +16,28 @@ export const appleApnHost = process.env.APN_ENV === "production" ? Host.producti
 export const firebaseAdminAuth = JSON.parse(process.env.FIREBASE_ADMIN_AUTH || "{}")
 
 /**
+ * Whether this process tracks rides.
+ *
+ * Rides are shared state: the redis `rides:*` hashes and real users' push tokens.
+ * A process that starts with tracking on picks up every active ride at boot
+ * (`scheduleExistingRides`), schedules a second set of notifications for each and
+ * deletes the ones it can't reschedule — so a local run pointed at the production
+ * redis would push duplicates to real passengers and end their Live Activities.
+ *
+ * It's therefore opt-in: RIDES_ENABLED decides, and when it's unset the fallback is
+ * "are we the deployed service?" — Railway injects RAILWAY_ENVIRONMENT_NAME/_ID into
+ * every runtime container, and nothing sets them on a laptop. Set RIDES_ENABLED=true
+ * on the deployment anyway, so tracking never hinges on Railway's variable names.
+ *
+ * With it off the boot reschedule is skipped and `/api/v1/ride/*` answers 503, so the
+ * process never reads or writes ride state at all.
+ */
+const isDeployedService = Boolean(
+  process.env.RAILWAY_ENVIRONMENT_NAME || process.env.RAILWAY_ENVIRONMENT_ID || process.env.RAILWAY_ENVIRONMENT,
+)
+export const ridesEnabled = process.env.RIDES_ENABLED ? process.env.RIDES_ENABLED === "true" : isDeployedService
+
+/**
  * Where timetable data comes from.
  *
  * - "gtfs" (default) — the Ministry of Transport GTFS feed ingested into Postgres,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,7 +3,7 @@ import express from "express"
 import { router } from "./routes/api"
 import { applySchema, getActiveFeed } from "./db"
 import { isRailApiConfigured } from "./requests/rail-api"
-import { env, port, railDataSource, siriPollerMode } from "./data/config"
+import { env, port, railDataSource, ridesEnabled, siriPollerMode } from "./data/config"
 import { connectToRedis } from "./data/redis"
 import { connectToApn } from "./utils/apn-utils"
 import { connectToFcm } from "./utils/fcm-utils"
@@ -41,7 +41,10 @@ app.listen(port, async () => {
     }
   }
 
-  scheduleExistingRides()
+  // Off unless this is the deployed service — a local run must never pick up
+  // (and reschedule, or delete) the rides of real passengers. See data/config.ts.
+  if (ridesEnabled) scheduleExistingRides()
+  else logger.warn(logNames.server.ridesDisabled)
 
   // The SIRI poller normally runs as its own Railway service (`bun run siri`);
   // this fallback hosts it here when the MOT-registered egress IP is ours.

--- a/apps/server/src/logs/logNames.ts
+++ b/apps/server/src/logs/logNames.ts
@@ -2,6 +2,7 @@ export const logNames = {
   server: {
     listening: "App listening",
     dataSource: "Serving timetable data from",
+    ridesDisabled: "Ride tracking is disabled, existing rides were left untouched",
   },
   redis: {
     connect: {

--- a/apps/server/src/routes/api.ts
+++ b/apps/server/src/routes/api.ts
@@ -1,5 +1,6 @@
 import { Router } from "express"
 
+import { ridesEnabled } from "../data/config"
 import { buildRide } from "../utils/ride-utils"
 import { RideRequestSchema } from "../types/ride"
 import { createRateLimiter } from "../utils/rate-limiter"
@@ -11,6 +12,12 @@ import { endRideNotifications, startRideNotifications, updateRideToken } from ".
 const router = Router()
 
 const rideRouter = Router()
+// Every route below reads or writes the shared rides state, so they're closed
+// while ride tracking is off (a local run, by default — see data/config.ts).
+rideRouter.use((req, res, next) => {
+  if (!ridesEnabled) return res.status(503).json({ success: false, reason: "rides_disabled" })
+  next()
+})
 rideRouter.use(createRateLimiter(10 * 60 * 1000, 10))
 
 rideRouter.post("/", bodyValidator(RideRequestSchema), async (req, res) => {


### PR DESCRIPTION
Rides are shared state: the `rides:*` hashes in redis and real passengers' push tokens. Any process that booted with a production REDIS_URL ran `scheduleExistingRides()` and picked up every active ride — scheduling a second set of notifications for each and deleting the ones it couldn't reschedule. A local run would push duplicates to real passengers and end their Live Activities.

Ride tracking is now opt-in through RIDES_ENABLED, falling back to "am I the deployed service?" (RAILWAY_ENVIRONMENT_NAME/_ID) when it's unset. With it off the boot reschedule is skipped — logged as a warning — and `/api/v1/ride/*` answers 503 `rides_disabled` ahead of validation, so the process never reads or writes ride state at all.