### PR TITLE
feat: change the station you switch trains at

### DIFF
--- a/apps/mobile/src/components/change-direction-button/change-direction-button.tsx
+++ b/apps/mobile/src/components/change-direction-button/change-direction-button.tsx
@@ -22,7 +22,13 @@ export function ChangeDirectionButton(props: ChangeDirectionButtonProps) {
 
   if (isLiquidGlassSupported) {
     return (
-      <Pressable {...props} style={buttonStyle}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={translate("plan.switchStations")}
+        accessibilityHint={translate("plan.switchStationsHint")}
+        {...props}
+        style={buttonStyle}
+      >
         <LiquidGlassView interactive style={styles.container} tintColor={color.secondary}>
           <Image source={upDownArrowIcon} style={styles.arrowIcon} />
         </LiquidGlassView>
@@ -34,6 +40,7 @@ export function ChangeDirectionButton(props: ChangeDirectionButtonProps) {
     <TouchableOpacity
       style={[styles.container, buttonStyle]}
       activeOpacity={onPress ? 0.9 : 1}
+      accessibilityRole="button"
       accessibilityLabel={translate("plan.switchStations")}
       accessibilityHint={translate("plan.switchStationsHint")}
       {...props}

--- a/apps/mobile/src/i18n/ar.json
+++ b/apps/mobile/src/i18n/ar.json
@@ -89,6 +89,9 @@
     "unknown": "مجهول",
     "trainNo": "قطار رقم",
     "changeAt": "تبديل في ",
+    "noRouteViaStation": "لا يوجد مسار بتبديل في هذه المحطة",
+    "changeStation": "التبديل في محطة أخرى",
+    "changeStationHint": "اختيار محطة أخرى لتبديل القطار",
     "platformStay": "الرجاء الانتظار في الرصيف",
     "platformChange": "الرجاء الانتقال الى رصيف",
     "waitingTime": "مدة الانتظار",
@@ -225,6 +228,8 @@
     }
   },
   "ride": {
+    "changeStationBlockedTitle": "الرحلة جارية",
+    "changeStationBlockedMessage": "أنهِ الرحلة لتغيير محطة التبديل.",
     "live": "Live",
     "startRide": "ابدأ الركوب",
     "stopRide": "توقف عن الركوب",

--- a/apps/mobile/src/i18n/en.json
+++ b/apps/mobile/src/i18n/en.json
@@ -95,6 +95,9 @@
     "unknown": "Unknown",
     "trainNo": "Train No.",
     "changeAt": "Change at ",
+    "noRouteViaStation": "No route changes at this station",
+    "changeStation": "Change at a different station",
+    "changeStationHint": "Pick another station to change trains at",
     "platformStay": "Stay at Platform",
     "platformChange": "Switch to Platform",
     "waitingTime": "Wait around",
@@ -275,6 +278,8 @@
     }
   },
   "ride": {
+    "changeStationBlockedTitle": "Ride in progress",
+    "changeStationBlockedMessage": "Stop the ride to change where you switch trains.",
     "live": "Live",
     "startRide": "Start Ride",
     "startNewRide": "Start New Ride",

--- a/apps/mobile/src/i18n/he.json
+++ b/apps/mobile/src/i18n/he.json
@@ -95,6 +95,9 @@
     "unknown": "לא ידוע",
     "trainNo": "רכבת מס'",
     "changeAt": "החלפה ב",
+    "noRouteViaStation": "לא נמצא מסלול עם החלפה בתחנה זו",
+    "changeStation": "החלפה בתחנה אחרת",
+    "changeStationHint": "בחירת תחנה אחרת להחלפת רכבת",
     "platformStay": "יש להשאר ברציף",
     "platformChange": "יש לעבור לרציף",
     "waitingTime": "זמן המתנה כ-",
@@ -276,6 +279,8 @@
     }
   },
   "ride": {
+    "changeStationBlockedTitle": "נסיעה פעילה",
+    "changeStationBlockedMessage": "יש לסיים את הנסיעה כדי לשנות את תחנת ההחלפה.",
     "live": "נסיעה",
     "startRide": "התחלת נסיעה",
     "startNewRide": "התחלת נסיעה חדשה",

--- a/apps/mobile/src/i18n/ru.json
+++ b/apps/mobile/src/i18n/ru.json
@@ -92,6 +92,9 @@
     "unknown": "Неизвестный",
     "trainNo": "Поезд номер",
     "changeAt": "Пересадка на ",
+    "noRouteViaStation": "Нет маршрута с пересадкой на этой станции",
+    "changeStation": "Пересадка на другой станции",
+    "changeStationHint": "Выберите другую станцию для пересадки",
     "platformStay": "Остаться на платформе",
     "platformChange": "Перейти на платформу",
     "waitingTime": "Время ожидания",
@@ -229,6 +232,8 @@
     }
   },
   "ride": {
+    "changeStationBlockedTitle": "Поездка активна",
+    "changeStationBlockedMessage": "Завершите поездку, чтобы изменить станцию пересадки.",
     "live": "Live",
     "startRide": "начать поездку",
     "startNewRide": "Начать новую поездку",

--- a/apps/mobile/src/models/ride/ride.ts
+++ b/apps/mobile/src/models/ride/ride.ts
@@ -193,7 +193,8 @@ export const useRideStore = create<RideStore>((set, get) => ({
       const destinationId = last(route.trains).destinationStationId
       const [date, time] = formatDateForAPI(route.departureTime)
 
-      routeApi.getRoutes(originId.toString(), destinationId.toString(), date, time).then((routes) => {
+      const options = { viaStation: route.viaStationId }
+      routeApi.getRoutes(originId.toString(), destinationId.toString(), date, time, options).then((routes) => {
         const currentRouteTrains = route.trains.map((train) => train.trainNumber).join()
         const currentRoute = routes.find((r) => currentRouteTrains === r.trains.map((train) => train.trainNumber).join())
 

--- a/apps/mobile/src/screens/route-details/components/alternative-change-stations.test.ts
+++ b/apps/mobile/src/screens/route-details/components/alternative-change-stations.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test"
+import { alternativeChangeStations } from "./alternative-change-stations"
+import type { Train } from "@/services/api"
+
+const train = (originStationId: number, destinationStationId: number, run: number[]) =>
+  ({
+    originStationId,
+    destinationStationId,
+    routeStations: run.map((stationId) => ({ stationId, arrivalTime: "", crowded: 0 })),
+  }) as unknown as Train
+
+describe("alternativeChangeStations", () => {
+  it("lists stations both trains call at, excluding the current change", () => {
+    // Board at 1, change at 4; the second train runs 9 -> 3 -> 4 -> 5 -> 6 and the rider gets off at 6.
+    const first = train(1, 4, [0, 1, 2, 3, 4, 5])
+    const second = train(4, 6, [9, 3, 4, 5, 6, 7])
+    expect(alternativeChangeStations(first, second)).toEqual(["3", "5"])
+  })
+
+  it("returns nothing when the runs share only the change station", () => {
+    expect(alternativeChangeStations(train(1, 4, [1, 2, 4]), train(4, 6, [4, 6]))).toEqual([])
+  })
+})

--- a/apps/mobile/src/screens/route-details/components/alternative-change-stations.ts
+++ b/apps/mobile/src/screens/route-details/components/alternative-change-stations.ts
@@ -1,0 +1,12 @@
+import type { Train } from "@/services/api"
+
+// Stops both trains share between boarding and alighting, minus the current change
+export function alternativeChangeStations(firstTrain: Train, secondTrain: Train): string[] {
+  const firstRun = firstTrain.routeStations.map((s) => s.stationId)
+  const secondRun = secondTrain.routeStations.map((s) => s.stationId)
+  const boardAt = firstRun.indexOf(firstTrain.originStationId)
+  const alightAt = secondRun.indexOf(secondTrain.destinationStationId)
+  const afterBoarding = firstRun.slice(boardAt + 1)
+  const beforeAlighting = new Set(secondRun.slice(0, alightAt === -1 ? undefined : alightAt))
+  return afterBoarding.filter((id) => id !== firstTrain.destinationStationId && beforeAlighting.has(id)).map(String)
+}

--- a/apps/mobile/src/screens/route-details/components/route-exchange-details.tsx
+++ b/apps/mobile/src/screens/route-details/components/route-exchange-details.tsx
@@ -1,11 +1,16 @@
 import React from "react"
-import { View, Image, ViewStyle, Dimensions } from "react-native"
+import { View, Image, ViewStyle, Dimensions, Alert } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
 import { Text, ChangeDirectionButton } from "@/components"
 import { color, spacing, fontScale } from "@/theme"
 import { intervalToDuration, formatDuration, addMinutes, millisecondsToMinutes, milliseconds, Duration } from "date-fns"
 import { dateFnsLocalization, translate } from "@/i18n"
 import { Train } from "@/services/api"
+import { useRouter } from "expo-router"
+import HapticFeedback from "react-native-haptic-feedback"
+import { trackEvent } from "@/services/analytics"
+import { alternativeChangeStations } from "./alternative-change-stations"
+import { useRideStore } from "@/models"
 
 const importantIcon = require("../../../../assets/important.png")
 const clockIcon = require("../../../../assets/clock.png")
@@ -30,6 +35,19 @@ type RouteExchangeProps = {
 
 export const RouteExchangeDetails = (props: RouteExchangeProps) => {
   const { stationName, arrivalPlatform, departurePlatform, firstTrain, secondTrain, style } = props
+  const router = useRouter()
+  const isRideInProgress = useRideStore((s) => !!s.id)
+
+  const onChangeStationPress = () => {
+    if (isRideInProgress) {
+      Alert.alert(translate("ride.changeStationBlockedTitle"), translate("ride.changeStationBlockedMessage"))
+      return
+    }
+    HapticFeedback.trigger("impactLight")
+    trackEvent("change_station_btn_press")
+    const stationIds = alternativeChangeStations(firstTrain, secondTrain).join(",")
+    router.push({ pathname: "/select-station", params: { selectionType: "via", stationIds } })
+  }
 
   const platformDetailText = (() => {
     if (arrivalPlatform === departurePlatform) {
@@ -50,7 +68,9 @@ export const RouteExchangeDetails = (props: RouteExchangeProps) => {
     return intervalToDuration({ start: arrivalTime, end: departureTime })
   })()
 
-  const exchangeDurationText = formatDuration(exchangeDuration, { locale: dateFnsLocalization })
+  const exchangeDurationText = formatDuration(exchangeDuration, {
+    locale: dateFnsLocalization,
+  })
 
   const isExchangeSafe = (() => {
     const exchangeMs = milliseconds(exchangeDuration)
@@ -59,7 +79,15 @@ export const RouteExchangeDetails = (props: RouteExchangeProps) => {
 
   return (
     <View style={[styles.wrapper, style]}>
-      {DISPLAY_EXCHANGE_ICON && <ChangeDirectionButton buttonStyle={styles.icon} />}
+      {DISPLAY_EXCHANGE_ICON && (
+        <ChangeDirectionButton
+          testID="change-station-button"
+          buttonStyle={styles.icon}
+          onPress={onChangeStationPress}
+          accessibilityLabel={translate("routeDetails.changeStation")}
+          accessibilityHint={translate("routeDetails.changeStationHint")}
+        />
+      )}
       <View>
         <Text style={styles.stationName}>
           {translate("routeDetails.changeAt")}
@@ -71,7 +99,12 @@ export const RouteExchangeDetails = (props: RouteExchangeProps) => {
             <Text style={styles.infoText}>{platformDetailText}</Text>
           </View>
           <View
-            style={[styles.infoDetailWrapper, { marginBottom: isExchangeSafe ? (fontScale > 1 ? spacing[3] : 0) : spacing[1] }]}
+            style={[
+              styles.infoDetailWrapper,
+              {
+                marginBottom: isExchangeSafe ? (fontScale > 1 ? spacing[3] : 0) : spacing[1],
+              },
+            ]}
           >
             <Image style={styles.infoIcon} source={clockIcon} />
             <Text style={styles.infoText}>

--- a/apps/mobile/src/screens/route-details/components/route-exchange-details.tsx
+++ b/apps/mobile/src/screens/route-details/components/route-exchange-details.tsx
@@ -36,7 +36,8 @@ type RouteExchangeProps = {
 export const RouteExchangeDetails = (props: RouteExchangeProps) => {
   const { stationName, arrivalPlatform, departurePlatform, firstTrain, secondTrain, style } = props
   const router = useRouter()
-  const isRideInProgress = useRideStore((s) => !!s.id)
+  const isRideInProgress = useRideStore((s) => s.loading || !!s.id)
+  const alternatives = alternativeChangeStations(firstTrain, secondTrain)
 
   const onChangeStationPress = () => {
     if (isRideInProgress) {
@@ -45,8 +46,7 @@ export const RouteExchangeDetails = (props: RouteExchangeProps) => {
     }
     HapticFeedback.trigger("impactLight")
     trackEvent("change_station_btn_press")
-    const stationIds = alternativeChangeStations(firstTrain, secondTrain).join(",")
-    router.push({ pathname: "/select-station", params: { selectionType: "via", stationIds } })
+    router.push({ pathname: "/select-station", params: { selectionType: "via", stationIds: alternatives.join(",") } })
   }
 
   const platformDetailText = (() => {
@@ -79,7 +79,8 @@ export const RouteExchangeDetails = (props: RouteExchangeProps) => {
 
   return (
     <View style={[styles.wrapper, style]}>
-      {DISPLAY_EXCHANGE_ICON && (
+      {DISPLAY_EXCHANGE_ICON && alternatives.length === 0 && <ChangeDirectionButton buttonStyle={styles.icon} />}
+      {DISPLAY_EXCHANGE_ICON && alternatives.length > 0 && (
         <ChangeDirectionButton
           testID="change-station-button"
           buttonStyle={styles.icon}

--- a/apps/mobile/src/screens/route-details/replace-change-station.ts
+++ b/apps/mobile/src/screens/route-details/replace-change-station.ts
@@ -1,0 +1,22 @@
+import { useNavigationParamsStore } from "@/models/navigation-params/navigation-params"
+import { useSettingsStore } from "@/models"
+import { RouteApi } from "@/services/api/route-api"
+import { formatDateForAPI } from "@/utils/helpers/date-helpers"
+
+// Re-plan the current route through `stationId`, keeping the same boarding time
+export async function replaceChangeStation(stationId: string): Promise<boolean> {
+  const { routeItem, originId, destinationId, setRouteItem } = useNavigationParamsStore.getState()
+  if (!routeItem || !originId || !destinationId) return false
+
+  const [date, hour] = formatDateForAPI(routeItem.departureTime)
+  const { hideSlowTrains } = useSettingsStore.getState()
+  const routes = await new RouteApi().getRoutes(originId, destinationId, date, hour, { hideSlowTrains, viaStation: stationId })
+
+  const sameBoarding = routes.find((route) => route.departureTime === routeItem.departureTime)
+  const nextBoarding = routes.find((route) => route.departureTime > routeItem.departureTime)
+  const replacement = sameBoarding ?? nextBoarding
+  if (!replacement) return false
+
+  setRouteItem({ ...replacement, viaStationId: stationId })
+  return true
+}

--- a/apps/mobile/src/screens/route-details/route-details-screen.tsx
+++ b/apps/mobile/src/screens/route-details/route-details-screen.tsx
@@ -49,6 +49,7 @@ export function RouteDetailsScreen() {
   } = useNavigationParamsStore(
     useShallow((s) => ({ routeItem: s.routeItem, originId: s.originId, destinationId: s.destinationId })),
   )
+  const viaStationId = paramsRouteItem.viaStationId
   const {
     rideRoute,
     id: rideId,
@@ -66,13 +67,14 @@ export function RouteDetailsScreen() {
   // Periodically refetch route data to catch platform changes and delays.
   // Skip when ride is active — the ride polling already handles updates.
   const { data: freshRouteItem } = useQuery(
-    ["routeDetails", originId, destinationId, paramsRouteItem.departureTime, ...trainNumbers],
+    ["routeDetails", originId, destinationId, viaStationId, paramsRouteItem.departureTime, ...trainNumbers],
     async () => {
       const [date, time] = formatDateForAPI(paramsRouteItem.departureTime)
       const originId = paramsRouteItem.trains[0].originStationId.toString()
       const destinationId = paramsRouteItem.trains[paramsRouteItem.trains.length - 1].destinationStationId.toString()
-      const routes = await routeApi.getRoutes(originId, destinationId, date, time)
-      return getSelectedRide(routes, trainNumbers) ?? paramsRouteItem
+      const routes = await routeApi.getRoutes(originId, destinationId, date, time, { viaStation: viaStationId })
+      const fresh = getSelectedRide(routes, trainNumbers)
+      return fresh ? { ...fresh, viaStationId } : paramsRouteItem
     },
     {
       initialData: paramsRouteItem,

--- a/apps/mobile/src/screens/select-station/recent-searches-box/recent-searches-box.tsx
+++ b/apps/mobile/src/screens/select-station/recent-searches-box/recent-searches-box.tsx
@@ -10,15 +10,19 @@ import { isDarkMode, spacing } from "@/theme"
 import { stationLocale, stationsObject } from "@/data/stations"
 import { StationSearchEntry } from "./station-search-entry"
 import { useRouter } from "expo-router"
+import type { SelectionType } from "../select-station-screen"
 
 type RecentSearchesBoxProps = {
-  selectionType: "origin" | "destination"
+  selectionType: SelectionType
 }
 
 export function RecentSearchesBox(props: RecentSearchesBoxProps) {
   const router = useRouter()
   const { setOrigin, setDestination } = useRoutePlanStore(
-    useShallow((s) => ({ setOrigin: s.setOrigin, setDestination: s.setDestination })),
+    useShallow((s) => ({
+      setOrigin: s.setOrigin,
+      setDestination: s.setDestination,
+    })),
   )
   const { entries, save, remove } = useRecentSearchesStore(
     useShallow((s) => ({ entries: s.entries, save: s.save, remove: s.remove })),
@@ -39,6 +43,7 @@ export function RecentSearchesBox(props: RecentSearchesBoxProps) {
   const onStationPress = (entry) => {
     trackEvent("recent_station_selected")
     const station = { id: entry.id, name: entry.id }
+    save({ id: station.id })
 
     if (props.selectionType === "origin") {
       setOrigin(station)
@@ -46,7 +51,6 @@ export function RecentSearchesBox(props: RecentSearchesBoxProps) {
       setDestination(station)
     }
 
-    save({ id: station.id })
     router.back()
   }
 

--- a/apps/mobile/src/screens/select-station/select-station-screen.tsx
+++ b/apps/mobile/src/screens/select-station/select-station-screen.tsx
@@ -1,36 +1,62 @@
-import React, { useEffect, useRef, useState } from "react"
-import { View, Pressable, Platform } from "react-native"
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { View, Pressable, Platform, ActivityIndicator } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
 import { Screen, Text, StationCard, FavoriteRoutes } from "@/components"
 import { useShallow } from "zustand/react/shallow"
 import { useRoutePlanStore, useRecentSearchesStore, useFavoritesStore } from "@/models"
 import { useRouter, useLocalSearchParams } from "expo-router"
 import { spacing, isDarkMode } from "@/theme"
-import { NormalizedStation } from "@/data/stations"
+import { NormalizedStation, useStations } from "@/data/stations"
 import { SearchInput } from "./search-input"
 import { RecentSearchesBox } from "./recent-searches-box/recent-searches-box"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { FlashList, FlashListRef } from "@shopify/flash-list"
 import { useFilteredStations } from "@/hooks"
+import { replaceChangeStation } from "@/screens/route-details/replace-change-station"
+import * as Burnt from "burnt"
+import { translate } from "@/i18n"
+
+export type SelectionType = "origin" | "destination" | "via"
 
 export function SelectStationScreen() {
   const router = useRouter()
-  const { selectionType } = useLocalSearchParams<{ selectionType: "origin" | "destination" }>()
+  const { selectionType, stationIds } = useLocalSearchParams<{ selectionType: SelectionType; stationIds?: string }>()
+  const allStations = useStations()
+  const allowedStations = useMemo(() => {
+    if (!stationIds) return undefined
+    const ids = stationIds.split(",")
+    return ids.map((id) => allStations.find((s) => s.id === id)).filter((s): s is NormalizedStation => !!s)
+  }, [stationIds, allStations])
   const { setOrigin, setDestination } = useRoutePlanStore(
-    useShallow((s) => ({ setOrigin: s.setOrigin, setDestination: s.setDestination })),
+    useShallow((s) => ({
+      setOrigin: s.setOrigin,
+      setDestination: s.setDestination,
+    })),
   )
   const saveRecentSearch = useRecentSearchesStore((s) => s.save)
   const recentSearchEntries = useRecentSearchesStore((s) => s.entries)
   const favoriteRoutesData = useFavoritesStore((s) => s.routes)
-  const insets = useSafeAreaInsets()
   const [searchTerm, setSearchTerm] = useState("")
+  const [isReplacing, setIsReplacing] = useState(false)
   const { filteredStations } = useFilteredStations(searchTerm)
+  const listData = allowedStations ?? filteredStations
   const listRef = useRef<FlashListRef<NormalizedStation>>(null)
 
   // Scroll back to the top whenever the search results change.
   useEffect(() => {
     listRef.current?.scrollToOffset({ offset: 0, animated: false })
   }, [searchTerm])
+
+  const pickChangeStation = async (stationId: string) => {
+    if (isReplacing) return
+    setIsReplacing(true)
+    const replaced = await replaceChangeStation(stationId).catch(() => false)
+    setIsReplacing(false)
+    if (!replaced) {
+      Burnt.alert({ title: translate("routeDetails.noRouteViaStation"), preset: "error", message: "" })
+      return
+    }
+    router.back()
+  }
 
   const renderItem = (station: NormalizedStation) => (
     <StationCard
@@ -39,14 +65,17 @@ export function SelectStationScreen() {
       image={station.image}
       style={styles.stationCard}
       onPress={() => {
+        saveRecentSearch({ id: station.id })
         if (selectionType === "origin") {
           setOrigin(station)
         } else if (selectionType === "destination") {
           setDestination(station)
+        } else if (selectionType === "via") {
+          pickChangeStation(station.id)
+          return
         } else {
           throw new Error("Selection type was not provided.")
         }
-        saveRecentSearch({ id: station.id })
         router.back()
       }}
     />
@@ -60,13 +89,10 @@ export function SelectStationScreen() {
       unsafe={true}
       statusBarBackgroundColor={isDarkMode ? "#1c1c1e" : "#f2f2f7"}
     >
-      <View
-        style={[
-          styles.searchBarWrapper,
-          { paddingTop: insets.top > 20 ? insets.top : Platform.select({ ios: 27.5, android: 12.5 }) },
-        ]}
-      >
-        <SearchInput searchTerm={searchTerm} setSearchTerm={setSearchTerm} autoFocus={favoriteRoutesData.length < 2} />
+      <View style={styles.searchBarWrapper}>
+        {!allowedStations && (
+          <SearchInput searchTerm={searchTerm} setSearchTerm={setSearchTerm} autoFocus={favoriteRoutesData.length < 2} />
+        )}
         <Pressable testID="cancel-station-selection" onPress={() => router.back()}>
           <Text style={styles.cancelLink} tx="common.cancel" />
         </Pressable>
@@ -74,37 +100,48 @@ export function SelectStationScreen() {
 
       <FlashList
         ref={listRef}
-        data={filteredStations}
+        data={listData}
         renderItem={({ item }) => renderItem(item)}
         keyExtractor={(item) => item.id}
         keyboardShouldPersistTaps="handled"
+        contentContainerStyle={styles.listContent}
+        ListFooterComponent={isReplacing ? <ActivityIndicator style={{ marginTop: spacing[3] }} /> : null}
         // Disabled: otherwise FlashList may scroll the list out of view when results change between keystrokes.
         maintainVisibleContentPosition={{ disabled: true }}
-        ListEmptyComponent={() => (
-          <View>
-            <RecentSearchesBox selectionType={selectionType} />
-            {recentSearchEntries.length > 1 && <FavoriteRoutes />}
-          </View>
-        )}
+        ListEmptyComponent={() =>
+          allowedStations ? null : (
+            <View>
+              <RecentSearchesBox selectionType={selectionType} />
+              {recentSearchEntries.length > 1 && <FavoriteRoutes />}
+            </View>
+          )
+        }
       />
     </Screen>
   )
 }
 
-const styles = StyleSheet.create((theme) => ({
+const styles = StyleSheet.create((theme, rt) => ({
   root: {
     backgroundColor: theme.colors.secondaryBackground,
     flex: 1,
   },
+  listContent: {
+    paddingBottom: rt.insets.bottom + theme.spacing[0],
+  },
   searchBarWrapper: {
     flexDirection: "row",
     alignItems: "center",
+    paddingTop: rt.insets.top > 20 ? rt.insets.top : Platform.select({ ios: 27.5, android: 12.5 }),
     paddingHorizontal: theme.spacing[3],
     paddingBottom: theme.spacing[3],
     marginBottom: theme.spacing[3],
     backgroundColor: theme.colors.background,
     borderBottomWidth: 0.75,
-    borderBottomColor: Platform.select({ ios: theme.colors.dimmer, android: isDarkMode ? "#3a3a3c" : "lightgrey" }),
+    borderBottomColor: Platform.select({
+      ios: theme.colors.dimmer,
+      android: isDarkMode ? "#3a3a3c" : "lightgrey",
+    }),
   },
   stationCard: {
     marginHorizontal: theme.spacing[3],

--- a/apps/mobile/src/screens/select-station/select-station-screen.tsx
+++ b/apps/mobile/src/screens/select-station/select-station-screen.tsx
@@ -65,10 +65,11 @@ export function SelectStationScreen() {
       image={station.image}
       style={styles.stationCard}
       onPress={() => {
-        saveRecentSearch({ id: station.id })
         if (selectionType === "origin") {
+          saveRecentSearch({ id: station.id })
           setOrigin(station)
         } else if (selectionType === "destination") {
+          saveRecentSearch({ id: station.id })
           setDestination(station)
         } else if (selectionType === "via") {
           pickChangeStation(station.id)

--- a/apps/mobile/src/services/api/e2e-route-fixtures.ts
+++ b/apps/mobile/src/services/api/e2e-route-fixtures.ts
@@ -114,7 +114,10 @@ function train({
 function route(
   trains: Train[],
   duration: string,
-  flags: Pick<RouteItem, "isMuchLonger" | "isMuchShorter"> = { isMuchLonger: false, isMuchShorter: false },
+  flags: Pick<RouteItem, "isMuchLonger" | "isMuchShorter"> = {
+    isMuchLonger: false,
+    isMuchShorter: false,
+  },
 ): RouteItem {
   const departureTime = trains[0].departureTime
   const arrivalTime = trains[trains.length - 1].arrivalTime
@@ -152,7 +155,7 @@ export function getE2ERoutes(
   destinationId: string,
   date: string,
   hour: string,
-  options: { hideSlowTrains?: boolean } = {},
+  options: { hideSlowTrains?: boolean; viaStation?: string } = {},
 ): RouteItem[] {
   const origin = Number(originId)
   const destination = Number(destinationId)

--- a/apps/mobile/src/services/api/e2e-route-fixtures.ts
+++ b/apps/mobile/src/services/api/e2e-route-fixtures.ts
@@ -208,5 +208,10 @@ export function getE2ERoutes(
     ),
   ].sort((a, b) => a.departureTime - b.departureTime)
 
-  return options.hideSlowTrains ? routes.filter((route) => !route.isMuchLonger) : routes
+  const viaStation = options.viaStation ? Number(options.viaStation) : undefined
+  return routes.filter((route) => {
+    if (options.hideSlowTrains && route.isMuchLonger) return false
+    if (viaStation === undefined) return true
+    return route.trains.slice(0, -1).some((t) => t.destinationStationId === viaStation)
+  })
 }

--- a/apps/mobile/src/services/api/rail-api.types.ts
+++ b/apps/mobile/src/services/api/rail-api.types.ts
@@ -106,6 +106,8 @@ export type RouteItem = {
   isMuchShorter: boolean
   isCancelled: boolean
   trains: Train[]
+  // Change station the rider picked
+  viaStationId?: string
 }
 
 export interface Title {

--- a/apps/mobile/src/services/api/ride-api.ts
+++ b/apps/mobile/src/services/api/ride-api.ts
@@ -38,6 +38,7 @@ export class RideApi {
         originId: head(route.trains).originStationId,
         destinationId: last(route.trains).destinationStationId,
         trains: route.trains.map((train) => train.trainNumber),
+        viaStationId: route.viaStationId ? Number(route.viaStationId) : undefined,
       })
     } catch (error) {
       throw toRideApiError(error)

--- a/apps/mobile/src/services/api/route-api.ts
+++ b/apps/mobile/src/services/api/route-api.ts
@@ -16,7 +16,7 @@ export class RouteApi {
     destinationId: string,
     date: string,
     hour: string,
-    options: { hideSlowTrains?: boolean } = {},
+    options: { hideSlowTrains?: boolean; viaStation?: string } = {},
   ): Promise<RouteItem[]> {
     if (!originId || !destinationId) throw new Error("Missing origin / destination data")
 
@@ -35,6 +35,7 @@ export class RouteApi {
         scheduleType: "ByDeparture",
         languageId: "Hebrew",
         hideSlowTrains: options.hideSlowTrains ?? false,
+        ...(options.viaStation ? { viaStation: parseInt(options.viaStation) } : {}),
       }
 
       const response: AxiosResponse<RailApiGetRoutesResult> = await this.api.axiosInstance.post(

--- a/apps/mobile/targets/widget/Live Activity/Activity.swift
+++ b/apps/mobile/targets/widget/Live Activity/Activity.swift
@@ -42,6 +42,7 @@ struct BetterRailActivityAttributes: ActivityAttributes {
   var departureDate: Date { isoDateStringToDate(route.departureTime) }
   var arrivalDate: Date { isoDateStringToDate(route.arrivalTime) }
   var trainNumbers: [Int] { route.trains.map { $0.trainNumber } }
+  var viaStationId: Int? { route.viaStationId.flatMap(Int.init) }
   
   var frequentPushesEnabled: Bool = true
 }
@@ -137,7 +138,7 @@ class LiveActivitiesController {
   private func registerLiveActivity(_ activity: LiveActivityRoute, token: String) async {
     let details = activity.attributes
           
-    let ride = Ride(token: token, departureDate: details.departureTime, originId: details.originStationId, destinationId: details.destinationStationId, trains: details.trainNumbers, locale: "en")
+    let ride = Ride(token: token, departureDate: details.departureTime, originId: details.originStationId, destinationId: details.destinationStationId, trains: details.trainNumbers, locale: "en", viaStationId: details.viaStationId)
 
     Task.init {
       do {

--- a/apps/mobile/targets/widget/Live Activity/ActivityNotificationsAPI.swift
+++ b/apps/mobile/targets/widget/Live Activity/ActivityNotificationsAPI.swift
@@ -16,8 +16,9 @@ struct Ride: Encodable, Identifiable {
     let trains: [Int]
     let locale: String
     let provider: String
+    let viaStationId: Int?
   
-  init(token: String, departureDate: String, originId: Int, destinationId: Int, trains: [Int], locale: String) {
+  init(token: String, departureDate: String, originId: Int, destinationId: Int, trains: [Int], locale: String, viaStationId: Int? = nil) {
     self.token = token
     self.departureDate = departureDate
     self.originId = originId
@@ -25,6 +26,7 @@ struct Ride: Encodable, Identifiable {
     self.trains = trains
     self.locale = locale
     self.provider = "ios"
+    self.viaStationId = viaStationId
   }
 }
 

--- a/apps/mobile/targets/widget/Shared/RouteModel.swift
+++ b/apps/mobile/targets/widget/Shared/RouteModel.swift
@@ -31,6 +31,7 @@ struct Route: Identifiable, Codable, Hashable {
     let departureTime: String
     let arrivalTime: String
     let trains: [Train]
+    var viaStationId: String? = nil
     var isExchange: Bool { trains.count > 1 }
     var delay: Int { trains.first?.delay ?? 0 }
     var isTomorrow: Bool {

--- a/apps/server/src/data/redis.ts
+++ b/apps/server/src/data/redis.ts
@@ -26,9 +26,9 @@ export const getRedisClient = (): RedisClientType | undefined => client
 
 export const addRide = async (ride: Ride): Promise<boolean> => {
   try {
-    const promises = Object.entries(omit(ride, "rideId")).map(([key, value]) =>
-      client.hSet(getKey(ride.rideId), key, JSON.stringify(value)),
-    )
+    const promises = Object.entries(omit(ride, "rideId"))
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => client.hSet(getKey(ride.rideId), key, JSON.stringify(value)))
     await Promise.all(promises)
 
     logger.info(logNames.redis.rides.add.success, { rideId: ride.rideId, token: ride.token })

--- a/apps/server/src/requests/gtfs-route-api.ts
+++ b/apps/server/src/requests/gtfs-route-api.ts
@@ -720,14 +720,15 @@ const planVia = (
   for (const first of toVia) {
     const last = first[first.length - 1]
     const lastTrip = allTrips.get(last.tripKey)!
-    const arrAtVia = lastTrip.stops[last.alightIndex].arrTs
+    const off = lastTrip.stops[last.alightIndex]
+    const arrAtVia = off.arrTs
 
     let best: Leg[] | null = null
     let bestArr = Infinity
     for (const next of onward) {
       const board = allTrips.get(next[0].tripKey)!.stops[next[0].boardIndex]
       const stayingAboard = next[0].tripKey === last.tripKey && next[0].boardIndex === last.alightIndex
-      if (!stayingAboard && displayTs(board) < arrAtVia + CONNECTION_LIMITS.minAt(viaStation, false)) continue
+      if (!stayingAboard && displayTs(board) < arrAtVia + CONNECTION_LIMITS.minAt(viaStation, stayingPut(off, board))) continue
       const arr = journeyArrivalTs(allTrips, next)
       if (arr < bestArr) {
         bestArr = arr

--- a/apps/server/src/requests/gtfs-route-api.ts
+++ b/apps/server/src/requests/gtfs-route-api.ts
@@ -62,7 +62,10 @@ const MAX_CONNECTION_MS = 70 * 60 * 1000
  * The ceiling is a single value too. Treating a roomier one as a fallback only
  * made journeys slower for no gain.
  */
-type ConnectionLimits = { minAt: (railId: number, onTheSameFace: boolean) => number; maxMs: number }
+type ConnectionLimits = {
+  minAt: (railId: number, onTheSameFace: boolean) => number
+  maxMs: number
+}
 const CONNECTION_LIMITS: ConnectionLimits = {
   minAt: (_railId, onTheSameFace) => (onTheSameFace ? MIN_CONNECTION_SAME_PLATFORM_MS : MIN_CONNECTION_MS),
   maxMs: MAX_CONNECTION_MS,
@@ -198,6 +201,8 @@ export type PlanOptions = {
   // Drop a direct train that a faster direct train (departing later, arriving
   // earlier) shadows. Off by default; set by the app's "hide slow trains" toggle.
   hideSlowTrains?: boolean
+  // Route every journey through this station
+  viaStation?: number
 }
 
 export type Leg = { tripKey: string; boardIndex: number; alightIndex: number }
@@ -305,7 +310,12 @@ const fetchDayTrips = async (feedId: string, serviceDate: string): Promise<DayTr
     const tripKey = `${serviceDate}#${row.trip_id}`
     let trip = trips.get(tripKey)
     if (!trip) {
-      trip = { tripKey, trainNumber: row.train_number, routeId: row.route_id, stops: [] }
+      trip = {
+        tripKey,
+        trainNumber: row.train_number,
+        routeId: row.route_id,
+        stops: [],
+      }
       trips.set(tripKey, trip)
     }
     trip.stops.push({
@@ -452,7 +462,10 @@ const completeJourney = (
     const s = firstTrip.stops[j]
     const cur = first.get(s.railId)
     if (!cur || s.arrTs < cur.arr) {
-      first.set(s.railId, { arr: s.arrTs, leg: { tripKey: firstTrip.tripKey, boardIndex, alightIndex: j } })
+      first.set(s.railId, {
+        arr: s.arrTs,
+        leg: { tripKey: firstTrip.tripKey, boardIndex, alightIndex: j },
+      })
     }
   }
   rounds.push(first)
@@ -494,7 +507,14 @@ const completeJourney = (
         const s = trip.stops[j]
         const existing = current.get(s.railId)
         if (!existing || s.arrTs < existing.arr) {
-          current.set(s.railId, { arr: s.arrTs, leg: { tripKey: trip.tripKey, boardIndex: call.index, alightIndex: j } })
+          current.set(s.railId, {
+            arr: s.arrTs,
+            leg: {
+              tripKey: trip.tripKey,
+              boardIndex: call.index,
+              alightIndex: j,
+            },
+          })
         }
       }
     }
@@ -589,7 +609,13 @@ const optimizeTransfers = (allTrips: DayTrips, legs: Leg[], limits: ConnectionLi
       if (p2 === undefined) continue
       const window = displayTs(f2.stops[p2]) - f1.stops[p1].arrTs
       if (window < limits.minAt(st, stayingPut(f1.stops[p1], f2.stops[p2])) || window > limits.maxMs) continue
-      const cand = { station: st, window, transferTime: f1.stops[p1].arrTs, p1, p2 }
+      const cand = {
+        station: st,
+        window,
+        transferTime: f1.stops[p1].arrTs,
+        p1,
+        p2,
+      }
       if (best === null || isBetterTransfer(cand, best)) best = cand
     }
 
@@ -671,6 +697,70 @@ const buildTrain = (allTrips: DayTrips, leg: Leg, realtime: RealtimeLookup): Tra
 // epoch ms (already anchored at UTC midnight + offset) -> naive wall-clock ISO
 const localIsoFromTs = (ts: number): string => new Date(ts).toISOString().slice(0, 19)
 
+// Origin -> via, each completed with the earliest onward journey via -> destination.
+// A train running straight through the via station stays one leg.
+const planVia = (
+  allTrips: DayTrips,
+  fromStation: number,
+  viaStation: number,
+  toStation: number,
+  queryTs: number,
+  endTs: number,
+  options: PlanOptions,
+): Leg[][] => {
+  const toVia = planLegs(allTrips, fromStation, viaStation, queryTs, endTs, options)
+  if (toVia.length === 0) return []
+  // Onward journeys may run past midnight
+  const onward = planLegs(allTrips, viaStation, toStation, queryTs, Infinity, options)
+  if (onward.length === 0) return []
+
+  type Candidate = { legs: Leg[]; depTs: number; arrTs: number }
+  const candidates: Candidate[] = []
+  const seen = new Set<string>()
+  for (const first of toVia) {
+    const last = first[first.length - 1]
+    const lastTrip = allTrips.get(last.tripKey)!
+    const arrAtVia = lastTrip.stops[last.alightIndex].arrTs
+
+    let best: Leg[] | null = null
+    let bestArr = Infinity
+    for (const next of onward) {
+      const board = allTrips.get(next[0].tripKey)!.stops[next[0].boardIndex]
+      const stayingAboard = next[0].tripKey === last.tripKey && next[0].boardIndex === last.alightIndex
+      if (!stayingAboard && displayTs(board) < arrAtVia + CONNECTION_LIMITS.minAt(viaStation, false)) continue
+      const arr = journeyArrivalTs(allTrips, next)
+      if (arr < bestArr) {
+        bestArr = arr
+        best = next
+      }
+    }
+    if (!best) continue
+
+    const legs =
+      best[0].tripKey === last.tripKey
+        ? [...first.slice(0, -1), { ...last, alightIndex: best[0].alightIndex }, ...best.slice(1)]
+        : [...first, ...best]
+    const boardAt = allTrips.get(legs[0].tripKey)!.stops[legs[0].boardIndex]
+    const key = legs.map((l) => allTrips.get(l.tripKey)!.trainNumber).join("-") + "@" + displayTs(boardAt)
+    if (seen.has(key)) continue
+    seen.add(key)
+    candidates.push({ legs, depTs: displayTs(boardAt), arrTs: bestArr })
+  }
+
+  // Same arrival: keep the one leaving latest
+  const bestByArrival = new Map<number, Candidate>()
+  for (const c of candidates) {
+    const held = bestByArrival.get(c.arrTs)
+    if (!held || c.depTs > held.depTs || (c.depTs === held.depTs && c.legs.length < held.legs.length)) {
+      bestByArrival.set(c.arrTs, c)
+    }
+  }
+  return [...bestByArrival.values()]
+    .sort((a, b) => a.depTs - b.depTs || a.arrTs - b.arrTs)
+    .slice(0, MAX_RESULTS)
+    .map((c) => c.legs)
+}
+
 /**
  * Pure planner: the itineraries for origin->destination from queryTs, over an
  * already-loaded trip table, as legs over that table. Lists trains by departure
@@ -686,6 +776,10 @@ export const planLegs = (
   endTs: number = Infinity,
   options: PlanOptions = {},
 ): Leg[][] => {
+  const { viaStation, ...rest } = options
+  if (viaStation !== undefined && viaStation !== fromStation && viaStation !== toStation) {
+    return planVia(allTrips, fromStation, viaStation, toStation, queryTs, endTs, rest)
+  }
   // Candidate first trains: those boardable at the origin within [queryTs, endTs].
   // endTs bounds the response to the requested day so it doesn't bleed into the
   // next one (which the client loads as a separate page) — but it is *inclusive*
@@ -712,7 +806,11 @@ export const planLegs = (
   }
   const firstTrains = [...originCalls.values()]
     .sort((a, b) => a.depTs - b.depTs || a.ord - b.ord)
-    .map((call) => ({ tripKey: call.trip.tripKey, boardIndex: call.index, depTs: call.depTs }))
+    .map((call) => ({
+      tripKey: call.trip.tripKey,
+      boardIndex: call.index,
+      depTs: call.depTs,
+    }))
 
   type Candidate = { legs: Leg[]; depTs: number; arrTs: number }
   let candidates: Candidate[] = []
@@ -762,7 +860,13 @@ export const planLegs = (
     const directAlight = trip.stops.findIndex((s, idx) => idx > ft.boardIndex && s.railId === toStation)
     if (directAlight > ft.boardIndex) {
       itineraries.push({
-        legs: [{ tripKey: ft.tripKey, boardIndex: ft.boardIndex, alightIndex: directAlight }],
+        legs: [
+          {
+            tripKey: ft.tripKey,
+            boardIndex: ft.boardIndex,
+            alightIndex: directAlight,
+          },
+        ],
         arrTs: trip.stops[directAlight].arrTs,
       })
       // Riding a direct train to the end isn't always the best use of it: some take
@@ -1298,12 +1402,16 @@ export const searchTrain = async (
 
   // The plan is a pure function of the feed, the day and the request, so it is
   // computed once and kept for as long as the feed is active.
-  const planKey = `${feed.feedId}#${date}#${fromStation}#${toStation}#${options.hideSlowTrains ? 1 : 0}`
+  const planKey = `${feed.feedId}#${date}#${fromStation}#${toStation}#${options.hideSlowTrains ? 1 : 0}#${options.viaStation ?? ""}`
   const legs = cachedPlan(planKey, () => planLegs(allTrips, fromStation, toStation, queryTs, endTs, options))
 
   // Scheduled platforms are baked into stop_times.platform_code at ingest, so the
   // response already carries them (loadDayTrips reads them) — no per-request API call.
-  return { result: { travels: legs.map((itinerary) => buildTravel(allTrips, itinerary, realtime)) } }
+  return {
+    result: {
+      travels: legs.map((itinerary) => buildTravel(allTrips, itinerary, realtime)),
+    },
+  }
 }
 
 export { invalidateDayCacheForFeed, loadDayTrips }

--- a/apps/server/src/requests/index.ts
+++ b/apps/server/src/requests/index.ts
@@ -6,7 +6,9 @@ import { getSelectedRide } from "../utils/ride-utils"
 export const getRouteForRide = async (ride: Ride) => {
   try {
     const routeApi = new RouteApi()
-    const routes = await routeApi.getRoutes(ride.originId, ride.destinationId, ride.departureDate, ride.locale)
+    const routes = await routeApi.getRoutes(ride.originId, ride.destinationId, ride.departureDate, ride.locale, {
+      viaStation: ride.viaStationId,
+    })
     const selected = getSelectedRide(routes, ride)
     if (!selected) {
       throw new Error("Didn't find the requested route in response")

--- a/apps/server/src/requests/route-api.ts
+++ b/apps/server/src/requests/route-api.ts
@@ -14,6 +14,7 @@ export class RouteApi {
     destinationId: number,
     departureDate: string | Date,
     locale: LanguageCode,
+    options: { viaStation?: number } = {},
   ): Promise<RouteItem[]> {
     if (!originId || !destinationId) throw new Error("Missing origin / destination data")
 
@@ -25,7 +26,7 @@ export class RouteApi {
     const response =
       railDataSource === "rail"
         ? await searchTrainOnRailApi(originId, destinationId, date, hour, "ByDeparture", locale)
-        : await searchTrain(originId, destinationId, date, hour, "ByDeparture")
+        : await searchTrain(originId, destinationId, date, hour, "ByDeparture", { viaStation: options.viaStation })
 
     if (!response?.result) {
       throw new Error("Error fetching results")

--- a/apps/server/src/routes/rail-api.ts
+++ b/apps/server/src/routes/rail-api.ts
@@ -22,16 +22,21 @@ const runTimetableSearch = async (
     hour: unknown
     scheduleType: unknown
     hideSlowTrains?: unknown
+    viaStation?: unknown
   },
 ) => {
   try {
+    const viaStation = Number(params.viaStation)
     const result = await searchTrain(
       Number(params.fromStation),
       Number(params.toStation),
       String(params.date),
       String(params.hour),
       toScheduleType(params.scheduleType),
-      { hideSlowTrains: toFlag(params.hideSlowTrains) },
+      {
+        hideSlowTrains: toFlag(params.hideSlowTrains),
+        viaStation: viaStation > 0 ? viaStation : undefined,
+      },
     )
     res.status(200).json(result)
   } catch (error: any) {
@@ -45,7 +50,7 @@ const runTimetableSearch = async (
 const handleSearchTrainRequest = async (req: Request, res: Response) => {
   if (railDataSource === "rail") return proxySearchTrainRequest(req, res)
 
-  const { fromStation, toStation, date, hour, scheduleType, hideSlowTrains } = req.query
+  const { fromStation, toStation, date, hour, scheduleType, hideSlowTrains, viaStation } = req.query
   await runTimetableSearch(res, {
     fromStation,
     toStation,
@@ -53,6 +58,7 @@ const handleSearchTrainRequest = async (req: Request, res: Response) => {
     hour,
     scheduleType: scheduleType === "1" ? "ByDeparture" : "ByArrival",
     hideSlowTrains,
+    viaStation,
   })
 }
 
@@ -83,8 +89,16 @@ const handleRailApiRequest = async (req: Request, res: Response) => {
   if (railDataSource === "rail") return railProxy(req, res)
 
   if (req.method === "POST" && isTimetableSearchPath(req.path)) {
-    const { fromStation, toStation, date, hour, scheduleType, hideSlowTrains } = req.body ?? {}
-    await runTimetableSearch(res, { fromStation, toStation, date, hour, scheduleType, hideSlowTrains })
+    const { fromStation, toStation, date, hour, scheduleType, hideSlowTrains, viaStation } = req.body ?? {}
+    await runTimetableSearch(res, {
+      fromStation,
+      toStation,
+      date,
+      hour,
+      scheduleType,
+      hideSlowTrains,
+      viaStation,
+    })
     return
   }
 

--- a/apps/server/src/tests/gtfs-planner.test.ts
+++ b/apps/server/src/tests/gtfs-planner.test.ts
@@ -12,7 +12,14 @@ const ts = (clock: string) =>
 const trip = (tripId: string, trainNumber: number, stops: [number, string, number][]): TripData => ({
   tripKey: `${DATE}#${tripId}`,
   trainNumber,
-  stops: stops.map(([railId, clock, platform]): StopNode => ({ railId, platform, arrTs: ts(clock), depTs: ts(clock) })),
+  stops: stops.map(
+    ([railId, clock, platform]): StopNode => ({
+      railId,
+      platform,
+      arrTs: ts(clock),
+      depTs: ts(clock),
+    }),
+  ),
 })
 
 const table = (...trips: TripData[]): DayTrips => new Map(trips.map((t) => [t.tripKey, t]))
@@ -1416,7 +1423,10 @@ describe("planTravels", () => {
       const lookup = (_d: string, trainNumber: number, railId: number) => {
         if (trainNumber !== 101) return { delayMin: 0 }
         // 3700: same as scheduled (1) -> no flag; 3500: 9 vs scheduled 2 -> flag.
-        return { delayMin: 0, platform: railId === 3700 ? 1 : railId === 3500 ? 9 : undefined }
+        return {
+          delayMin: 0,
+          platform: railId === 3700 ? 1 : railId === 3500 ? 9 : undefined,
+        }
       }
       const travels = planTravels(trips(), 3700, 3400, ts("07:00"), Infinity, lookup)
 
@@ -1585,5 +1595,53 @@ describe("planTravels", () => {
       const travels = planTravels(trips, 900, 1400, ts("07:00"))
       expect(changeStation(travels)).toBe(4900)
     })
+  })
+})
+
+describe("viaStation", () => {
+  // 3700 -> 3400 direct, or via 3500 with a change
+  const trips = table(
+    trip("direct", 101, [
+      [3700, "08:00", 1],
+      [3400, "08:30", 1],
+    ]),
+    trip("to-via", 201, [
+      [3700, "08:05", 2],
+      [3500, "08:25", 1],
+    ]),
+    trip("from-via", 202, [
+      [3500, "08:40", 2],
+      [3400, "09:10", 1],
+    ]),
+    trip("from-via-too-soon", 203, [
+      [3500, "08:27", 2],
+      [3400, "08:50", 1],
+    ]),
+  )
+
+  it("routes every journey through the chosen station", () => {
+    const travels = planTravels(trips, 3700, 3400, ts("07:00"), Infinity, undefined, { viaStation: 3500 })
+    expect(travels).toHaveLength(1)
+    expect(travels[0].trains.map((t) => t.trainNumber)).toEqual([201, 202])
+    expect(travels[0].trains[0].destinationStation).toBe(3500)
+  })
+
+  it("keeps a train that runs on through the via station as one leg", () => {
+    const through = table(
+      trip("through", 301, [
+        [3700, "08:00", 1],
+        [3500, "08:20", 1],
+        [3400, "08:40", 1],
+      ]),
+    )
+    const travels = planTravels(through, 3700, 3400, ts("07:00"), Infinity, undefined, { viaStation: 3500 })
+    expect(travels).toHaveLength(1)
+    expect(travels[0].trains).toHaveLength(1)
+    expect(travels[0].trains[0].stopStations.map((s: { stationId: number }) => s.stationId)).toEqual([3500])
+  })
+
+  it("ignores a via station that is the origin or the destination", () => {
+    const travels = planTravels(trips, 3700, 3400, ts("07:00"), Infinity, undefined, { viaStation: 3700 })
+    expect(travels.map((t) => t.trains[0].trainNumber)).toContain(101)
   })
 })

--- a/apps/server/src/tests/gtfs-planner.test.ts
+++ b/apps/server/src/tests/gtfs-planner.test.ts
@@ -1640,6 +1640,29 @@ describe("viaStation", () => {
     expect(travels[0].trains[0].stopStations.map((s: { stationId: number }) => s.stationId)).toEqual([3500])
   })
 
+  it("allows a four-minute same-platform connection at the via station", () => {
+    const tight = table(
+      trip("in", 401, [
+        [3700, "08:00", 1],
+        [3500, "08:25", 2],
+      ]),
+      trip("same-platform", 402, [
+        [3500, "08:29", 2],
+        [3400, "08:50", 1],
+      ]),
+      trip("other-platform", 403, [
+        [3500, "08:29", 3],
+        [3400, "08:55", 1],
+      ]),
+      trip("later", 404, [
+        [3500, "08:40", 3],
+        [3400, "09:10", 1],
+      ]),
+    )
+    const travels = planTravels(tight, 3700, 3400, ts("07:00"), Infinity, undefined, { viaStation: 3500 })
+    expect(travels.map((t) => t.trains.map((tr) => tr.trainNumber))).toEqual([[401, 402]])
+  })
+
   it("ignores a via station that is the origin or the destination", () => {
     const travels = planTravels(trips, 3700, 3400, ts("07:00"), Infinity, undefined, { viaStation: 3700 })
     expect(travels.map((t) => t.trains[0].trainNumber)).toContain(101)

--- a/apps/server/src/types/ride.ts
+++ b/apps/server/src/types/ride.ts
@@ -13,6 +13,7 @@ export const RideRequestSchema = z.object({
   destinationId: z.number().refine((value) => stationsObject[value], { message: "Destination station doesn't exist" }),
   trains: z.number().array().nonempty(),
   locale: z.nativeEnum(LanguageCode),
+  viaStationId: z.number().optional(),
 })
 
 export type RideRequest = z.infer<typeof RideRequestSchema>

--- a/apps/server/src/types/ride.ts
+++ b/apps/server/src/types/ride.ts
@@ -13,7 +13,10 @@ export const RideRequestSchema = z.object({
   destinationId: z.number().refine((value) => stationsObject[value], { message: "Destination station doesn't exist" }),
   trains: z.number().array().nonempty(),
   locale: z.nativeEnum(LanguageCode),
-  viaStationId: z.number().optional(),
+  viaStationId: z
+    .number()
+    .refine((value) => stationsObject[value], { message: "Via station doesn't exist" })
+    .optional(),
 })
 
 export type RideRequest = z.infer<typeof RideRequestSchema>


### PR DESCRIPTION
On a route with a change, tapping the arrows on the "Change at …" card opens a
picker of stations both trains stop at. Picking one re-plans the trip through
that station and swaps it in on the route details screen.

Server: new `viaStation` planner option (origin → via, then earliest onward
journey), also honoured for ride lookups so notifications match the chosen change.
Mobile: route items carry `viaStationId` so refreshes and live rides keep it;
changing the station during an active ride is blocked with an alert.


https://github.com/user-attachments/assets/0b00a9a5-f573-4c61-93ec-4543ae8e8c2d