### PR TITLE
chore(mobile): bump app version to 2.8.0

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -53,7 +53,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.13",
+  version: "2.8.0",
   updates: {
     enabled: !IS_E2E,
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",


### PR DESCRIPTION
Bumps `version` in `apps/mobile/app.config.ts` from 2.7.13 to 2.8.0.