### PR TITLE
feat(watch): drag to reorder favorites on watchOS 27

### DIFF
--- a/apps/mobile/src/models/favorites/favorites.ts
+++ b/apps/mobile/src/models/favorites/favorites.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import { Platform } from "react-native"
 import { setAnalyticsUserProperty } from "@/services/analytics"
-import { getIsWatchAppInstalled, updateApplicationContext, getIsPaired, WatchPayload } from "react-native-watch-connectivity"
+import { getIsWatchAppInstalled, updateApplicationContext, getIsPaired, watchEvents, WatchPayload } from "react-native-watch-connectivity"
 import Shortcuts from "react-native-quick-actions-shortcuts"
 import { stationLocale, stationsObject } from "@/data/stations"
 import { translate } from "@/i18n"
@@ -36,6 +36,7 @@ export interface FavoritesActions {
   add: (route: FavoriteRoute) => void
   remove: (routeId: string) => void
   rename: (routeId: string, newLabel: string) => void
+  reorder: (routeIds: string[]) => void
 }
 
 export type FavoritesStore = FavoritesState & FavoritesActions
@@ -118,7 +119,26 @@ export const useFavoritesStore = create<FavoritesStore>((set, get) => ({
     }))
     get().syncFavorites()
   },
+
+  reorder(routeIds) {
+    set((state) => {
+      const byId = new Map(state.routes.map((route) => [route.id, route]))
+      const ordered = routeIds.map((id) => byId.get(id)).filter((route): route is FavoriteRoute => !!route)
+      // Keep anything the watch didn't know about (e.g. added while offline)
+      const rest = state.routes.filter((route) => !routeIds.includes(route.id))
+      return { routes: [...ordered, ...rest] }
+    })
+    get().syncFavorites()
+  },
 }))
+
+// The watch app sends its reordered list back as user info
+if (Platform.OS === "ios") {
+  watchEvents.addListener("user-info", (payloads) => {
+    const latest = [...payloads].reverse().find((payload) => Array.isArray(payload.favoritesOrder))
+    if (latest) useFavoritesStore.getState().reorder(latest.favoritesOrder as string[])
+  })
+}
 
 export function getFavoritesSnapshot(state: FavoritesState) {
   return { routes: state.routes }

--- a/apps/mobile/src/models/favorites/favorites.ts
+++ b/apps/mobile/src/models/favorites/favorites.ts
@@ -132,9 +132,13 @@ export const useFavoritesStore = create<FavoritesStore>((set, get) => ({
   },
 }))
 
-// The watch app sends its reordered list back as user info
-if (Platform.OS === "ios") {
-  watchEvents.addListener("user-info", (payloads) => {
+let watchReorderListener: (() => void) | undefined
+
+// The watch app sends its reordered list back as user info. Registered only after hydration,
+// otherwise a queued payload could be applied to the empty store and then overwritten.
+function listenForWatchReorders() {
+  if (Platform.OS !== "ios" || watchReorderListener) return
+  watchReorderListener = watchEvents.addListener("user-info", (payloads) => {
     const latest = [...payloads].reverse().find((payload) => Array.isArray(payload.favoritesOrder))
     if (latest) useFavoritesStore.getState().reorder(latest.favoritesOrder as string[])
   })
@@ -145,10 +149,12 @@ export function getFavoritesSnapshot(state: FavoritesState) {
 }
 
 export function hydrateFavoritesStore(data: any) {
-  if (!data) return
-  useFavoritesStore.setState({
-    routes: data.routes ?? [],
-  })
-  // Sync favorites after hydration (replaces afterCreate)
-  useFavoritesStore.getState().syncFavorites()
+  if (data) {
+    useFavoritesStore.setState({
+      routes: data.routes ?? [],
+    })
+    // Sync favorites after hydration (replaces afterCreate)
+    useFavoritesStore.getState().syncFavorites()
+  }
+  listenForWatchReorders()
 }

--- a/apps/mobile/targets/watch-widget/FavoritesModel.swift
+++ b/apps/mobile/targets/watch-widget/FavoritesModel.swift
@@ -23,7 +23,7 @@ struct FavoritesModel {
   private var _routes: [FavoriteRoute]
   var routes: [FavoriteRoute] {
     get {
-      return _routes.sorted { $0.id < $1.id }
+      return _routes
     }
     set {
       _routes = newValue
@@ -47,8 +47,10 @@ struct FavoritesModel {
     
     // Data comes formatted as:
     // "1" (index) : "originId:3600,destinationId:3500,label:Home"
+    // The key is the position in the iPhone favorites list.
+    let orderedRoutes = routes.sorted { (Int($0.key) ?? 0) < (Int($1.key) ?? 0) }
     
-    for (key, value) in routes {
+    for (_, value) in orderedRoutes {
       // TODO: Extract information using Decodable?
       let route = String(describing: value).split(separator: ",")
       let originId = String(route[0].split(separator: ":")[1])
@@ -70,6 +72,15 @@ struct FavoritesModel {
     #else
     self.routes = favoriteRoutes
     #endif
+  }
+  
+  /// Moves `ids` so they sit before `beforeId`, or at the end when nil.
+  mutating func move(ids: [String], before beforeId: String?) {
+    let moving = _routes.filter { ids.contains($0.id) }
+    var remaining = _routes.filter { !ids.contains($0.id) }
+    let index = beforeId.flatMap { id in remaining.firstIndex { $0.id == id } } ?? remaining.count
+    remaining.insert(contentsOf: moving, at: index)
+    self.routes = remaining
   }
   
   static func getRoutesFromUserDefaults() -> [FavoriteRoute] {

--- a/apps/mobile/targets/watch/Models/FavoritesModel.swift
+++ b/apps/mobile/targets/watch/Models/FavoritesModel.swift
@@ -23,7 +23,7 @@ struct FavoritesModel {
   private var _routes: [FavoriteRoute]
   var routes: [FavoriteRoute] {
     get {
-      return _routes.sorted { $0.id < $1.id }
+      return _routes
     }
     set {
       _routes = newValue
@@ -47,8 +47,10 @@ struct FavoritesModel {
     
     // Data comes formatted as:
     // "1" (index) : "originId:3600,destinationId:3500,label:Home"
+    // The key is the position in the iPhone favorites list.
+    let orderedRoutes = routes.sorted { (Int($0.key) ?? 0) < (Int($1.key) ?? 0) }
     
-    for (key, value) in routes {
+    for (_, value) in orderedRoutes {
       // TODO: Extract information using Decodable?
       let route = String(describing: value).split(separator: ",")
       let originId = String(route[0].split(separator: ":")[1])
@@ -70,6 +72,15 @@ struct FavoritesModel {
     #else
     self.routes = favoriteRoutes
     #endif
+  }
+  
+  /// Moves `ids` so they sit before `beforeId`, or at the end when nil.
+  mutating func move(ids: [String], before beforeId: String?) {
+    let moving = _routes.filter { ids.contains($0.id) }
+    var remaining = _routes.filter { !ids.contains($0.id) }
+    let index = beforeId.flatMap { id in remaining.firstIndex { $0.id == id } } ?? remaining.count
+    remaining.insert(contentsOf: moving, at: index)
+    self.routes = remaining
   }
   
   static func getRoutesFromUserDefaults() -> [FavoriteRoute] {

--- a/apps/mobile/targets/watch/ViewModels/FavoritesViewModel.swift
+++ b/apps/mobile/targets/watch/ViewModels/FavoritesViewModel.swift
@@ -31,5 +31,11 @@ class FavoritesViewModel: NSObject, ObservableObject, WCSessionDelegate {
       self.model.updateRoutes(routes)
     }
   }
+  
+  /// Reorders locally and queues the new order for the iPhone app.
+  func moveRoutes(ids: [String], before beforeId: String?) {
+    model.move(ids: ids, before: beforeId)
+    session.transferUserInfo(["favoritesOrder": model.routes.map(\.id)])
+  }
 }
 

--- a/apps/mobile/targets/watch/Views/MainView.swift
+++ b/apps/mobile/targets/watch/Views/MainView.swift
@@ -5,10 +5,27 @@ struct MainView: View {
   @ObservedObject var favorites: FavoritesViewModel
   
   @State var selected: FavoriteRoute?
+  @State var path: [FavoriteRoute] = []
   @State var isSearching = false
   
   var body: some View {
-    if #available(watchOS 10.0, *), !favorites.routes.isEmpty {
+    if #available(watchOS 27.0, *), !favorites.routes.isEmpty {
+      NavigationStack(path: $path) {
+        reorderableFavorites
+          .navigationDestination(for: FavoriteRoute.self) { route in
+            FavoriteRouteView(route: RouteViewModel(origin: route.origin, destination: route.destination), label: route.label)
+          }
+          .navigationTitle("Better Rail")
+          .toolbar { searchToolbar }
+      }
+      .sheet(isPresented: $isSearching) { searchSheet }
+      .onOpenURL { url in
+        if let route = favoriteRoute(from: url) {
+          path = [route]
+        }
+        WidgetCenter.shared.reloadAllTimelines()
+      }
+    } else if #available(watchOS 10.0, *), !favorites.routes.isEmpty {
       NavigationSplitView {
         List(favorites.routes, selection: $selected) { route in
           NavigationLink(value: route) {
@@ -19,15 +36,7 @@ struct MainView: View {
         }
         .listStyle(.carousel)
         .navigationTitle("Better Rail")
-        .toolbar {
-          ToolbarItem(placement: .topBarLeading) {
-            Button {
-              self.isSearching = true
-            } label: {
-              Image(systemName: "magnifyingglass")
-            }
-          }
-        }
+        .toolbar { searchToolbar }
       } detail: {
         if let selected {
           FavoriteRouteView(route: RouteViewModel(origin: selected.origin, destination: selected.destination), label: selected.label)
@@ -36,20 +45,11 @@ struct MainView: View {
         }
       }
       .tabViewStyle(.verticalPage)
-      .sheet(isPresented: $isSearching, content: {
-        NavigationStack {
-          SearchView()
-        }
-      })
+      .sheet(isPresented: $isSearching) { searchSheet }
       .onOpenURL { url in
-        if url.host == "route",
-           let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-           let originId = components.queryItems?.first(where: { $0.name == "originId" })?.value,
-           let destinationId = components.queryItems?.first(where: { $0.name == "destinationId" })?.value,
-           let selectedRoute = favorites.routes.first(where: { $0.origin.id == originId && $0.destination.id == destinationId }) {
-          self.selected = selectedRoute
+        if let route = favoriteRoute(from: url) {
+          selected = route
         }
-
         WidgetCenter.shared.reloadAllTimelines()
       }
     } else {
@@ -79,6 +79,63 @@ struct MainView: View {
         .navigationTitle("Better Rail")
       }
     }
+  }
+}
+
+extension MainView {
+  /// Drag-to-reorder is new in watchOS 27. It doesn't fire inside a watchOS `List`, so this
+  /// branch lays the favorites out in a stack styled like the carousel rows.
+  @available(watchOS 27.0, *)
+  var reorderableFavorites: some View {
+    ScrollView {
+      VStack(spacing: 8) {
+        ForEach(favorites.routes) { route in
+          NavigationLink(value: route) {
+            FavoriteListItemView(route: route)
+              .padding(.horizontal, 12)
+              .frame(maxWidth: .infinity, minHeight: 90, alignment: .leading)
+              .background(StationImageBackground(route.origin.image))
+              .clipShape(RoundedRectangle(cornerRadius: 18))
+          }
+          .buttonStyle(.plain)
+        }
+        .reorderable()
+      }
+    }
+    .reorderContainer(for: FavoriteRoute.self) { difference in
+      var beforeId: String?
+      if case .before(let id) = difference.destination.position {
+        beforeId = id
+      }
+      favorites.moveRoutes(ids: difference.sources, before: beforeId)
+    }
+  }
+  
+  @available(watchOS 10.0, *)
+  var searchToolbar: some ToolbarContent {
+    ToolbarItem(placement: .topBarLeading) {
+      Button {
+        isSearching = true
+      } label: {
+        Image(systemName: "magnifyingglass")
+      }
+    }
+  }
+  
+  var searchSheet: some View {
+    NavigationStack {
+      SearchView()
+    }
+  }
+  
+  /// Resolves a widget deep link (widget://route?originId=…&destinationId=…) to a favorite.
+  func favoriteRoute(from url: URL) -> FavoriteRoute? {
+    guard url.host == "route",
+          let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let originId = components.queryItems?.first(where: { $0.name == "originId" })?.value,
+          let destinationId = components.queryItems?.first(where: { $0.name == "destinationId" })?.value
+    else { return nil }
+    return favorites.routes.first { $0.origin.id == originId && $0.destination.id == destinationId }
   }
 }
 


### PR DESCRIPTION
Adds drag-to-reorder for the watch favorites list on watchOS 27 using the new `reorderable()` / `reorderContainer` API, and syncs the new order back to the iPhone app.

- Watch keeps the iPhone's favorites order instead of sorting by id
- watchOS 27 renders the favorites in a reorderable stack; older versions keep the carousel list
- Reordered list is sent to the phone via `transferUserInfo`; the favorites store applies it with a new `reorder` action

Verified on the watchOS 27 simulator with the apple-preview project.