### PR TITLE
feat(mobile): show no-trains warning in native bottom toolbar on iOS 26+

### DIFF
--- a/apps/mobile/src/screens/route-list/components/route-list-warning.tsx
+++ b/apps/mobile/src/screens/route-list/components/route-list-warning.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from "react"
 import { Platform, View } from "react-native"
+import { StyleSheet } from "react-native-unistyles"
 import Animated, { FadeInDown } from "react-native-reanimated"
+import { Stack } from "expo-router"
+import { isLiquidGlassSupported, LiquidGlassView } from "@callstack/liquid-glass"
 import { BottomScreenSheet, Text } from "@/components"
 import { format } from "date-fns"
 import { dateFnsLocalization, translate } from "@/i18n"
@@ -8,6 +11,8 @@ import * as Burnt from "burnt"
 import { RouteListWarningModal, type WarningType } from "./route-list-warning-modal"
 
 const shouldDisplayModal = Platform.OS === "android"
+// iOS 26+ shows the warning in the native bottom toolbar instead of our custom sheet
+const useNativeToolbar = Platform.OS === "ios" && isLiquidGlassSupported
 
 export type { WarningType }
 
@@ -25,7 +30,9 @@ export interface RouteListModalProps {
 export const RouteListWarning = function RouteListWarning({ routesDate, warningType }: RouteListModalProps) {
   const [warningVisible, setWarningVisible] = useState(false)
   const [displayWarningSheet, setDisplayWarningSheet] = useState(false)
-  const formattedRoutesDate = format(routesDate, "eeee, dd/MM/yyyy", { locale: dateFnsLocalization })
+  const formattedRoutesDate = format(routesDate, "eeee, dd/MM/yyyy", {
+    locale: dateFnsLocalization,
+  })
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -69,6 +76,22 @@ export const RouteListWarning = function RouteListWarning({ routesDate, warningT
     setTimeout(() => setDisplayWarningSheet(true), 350)
   }
 
+  const warningContent = (
+    <View>
+      <Text preset="bold" tx={warningType === "different-hour" ? "modals.noTrainsFoundForHour" : "modals.noTrainsFoundForDate"} />
+      <Text style={{ fontSize: 14 }}>
+        {warningType === "different-hour" ? (
+          translate("modals.foundTrainsAtHour")
+        ) : (
+          <>
+            {translate("modals.foundTrainsAtDate")}
+            {formattedRoutesDate}
+          </>
+        )}
+      </Text>
+    </View>
+  )
+
   return (
     <>
       {shouldDisplayModal && (
@@ -79,28 +102,31 @@ export const RouteListWarning = function RouteListWarning({ routesDate, warningT
           onClose={handleClose}
         />
       )}
-      {displayWarningSheet && (
+      {displayWarningSheet && useNativeToolbar && (
+        <Stack.Toolbar>
+          <Stack.Toolbar.View hidesSharedBackground>
+            <LiquidGlassView style={styles.toolbarContent} tintColor="rgba(255, 159, 10, 0.55)">
+              {warningContent}
+            </LiquidGlassView>
+          </Stack.Toolbar.View>
+        </Stack.Toolbar>
+      )}
+      {displayWarningSheet && !useNativeToolbar && (
         <Animated.View entering={FadeInDown}>
-          <BottomScreenSheet style={{ backgroundColor: "orange" }}>
-            <View>
-              <Text
-                preset="bold"
-                tx={warningType === "different-hour" ? "modals.noTrainsFoundForHour" : "modals.noTrainsFoundForDate"}
-              />
-              <Text style={{ fontSize: 14 }}>
-                {warningType === "different-hour" ? (
-                  translate("modals.foundTrainsAtHour")
-                ) : (
-                  <>
-                    {translate("modals.foundTrainsAtDate")}
-                    {formattedRoutesDate}
-                  </>
-                )}
-              </Text>
-            </View>
-          </BottomScreenSheet>
+          <BottomScreenSheet style={{ backgroundColor: "orange" }}>{warningContent}</BottomScreenSheet>
         </Animated.View>
       )}
     </>
   )
 }
+
+const styles = StyleSheet.create((theme, rt) => ({
+  // The toolbar host has no intrinsic size, so the custom view needs an explicit width
+  toolbarContent: {
+    width: rt.screen.width - 32,
+    height: 64,
+    justifyContent: "center",
+    paddingHorizontal: 18,
+    borderRadius: 24,
+  },
+}))

--- a/apps/mobile/src/screens/route-list/route-list-screen.tsx
+++ b/apps/mobile/src/screens/route-list/route-list-screen.tsx
@@ -543,7 +543,7 @@ export function RouteListScreen() {
           contentContainerStyle={{
             paddingTop: spacing[4],
             paddingHorizontal: spacing[3],
-            paddingBottom: shouldShowWarning ? spacing[8] + 12 : spacing[3],
+            paddingBottom: shouldShowWarning ? spacing[8] + spacing[5] : spacing[3],
           }}
           initialScrollIndex={initialScrollIndex}
           // so the list will re-render when the ride route changes, and so the item will be marked


### PR DESCRIPTION
On iOS 26+ the "no trains found for the requested time/date" warning on the route list now renders inside expo-router's native `Stack.Toolbar` with an orange-tinted Liquid Glass background, replacing the custom orange bottom sheet. Older iOS versions and Android keep the existing sheet and modal. The toolbar host has no intrinsic size, so the custom view gets an explicit width and height. The list's bottom padding was raised so the last route card scrolls clear of the taller toolbar.

Verified on an iOS 27 simulator.